### PR TITLE
Fix new pytest failing build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(
     packages=["core_data_modules"],
     setup_requires=["pytest-runner"],
     install_requires=["deprecation", "six", "unicodecsv", "jsonpickle", "python-dateutil"],
-    tests_require=["pytest"]
+    tests_require=["pytest<=3.6.4"]
 )


### PR DESCRIPTION
Latest pytest requires gcc.

Other option for fixing is to install gcc in the docker container.