### PR TITLE
Change return type of Coda IO import

### DIFF
--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -233,8 +233,6 @@ class TracedDataCodaIO(object):
         :param overwrite_existing_codes: For messages which are already coded, whether to replace those codes with
                                          new codes from the Coda datafile.
         :type overwrite_existing_codes: bool
-        :return: TracedData objects with Coda data appended
-        :rtype: generator of TracedData
         """
         # TODO: This function assumes there is only one code scheme.
 
@@ -246,7 +244,6 @@ class TracedDataCodaIO(object):
 
         for td in data:
             if not overwrite_existing_codes and td.get(key_of_coded) is not None:
-                yield td
                 continue
 
             code = None
@@ -255,8 +252,6 @@ class TracedDataCodaIO(object):
                     code = row["deco_codeValue"]
 
             td.append_data({key_of_coded: code}, Metadata(user, Metadata.get_call_location(), time.time()))
-
-            yield td
 
 
 class TracedDataCodingCSVIO(object):

--- a/tests/traced_data/test_io.py
+++ b/tests/traced_data/test_io.py
@@ -116,8 +116,8 @@ class TestTracedDataCodaIO(unittest.TestCase):
 
         file_path = "tests/traced_data/resources/coda_import_data.csv"
         with open(file_path, "r") as f:
-            data = list(TracedDataCodaIO.import_coda_to_traced_data_iterable(
-                "test_user", data, "Gender", "Gender_clean", f))
+            TracedDataCodaIO.import_coda_to_traced_data_iterable(
+                "test_user", data, "Gender", "Gender_clean", f)
 
         expected_data = [
             {"URN": "+0012345000000", "Gender": "female", "Gender_clean": "X"},
@@ -138,8 +138,8 @@ class TestTracedDataCodaIO(unittest.TestCase):
 
         file_path = "tests/traced_data/resources/coda_import_data.csv"
         with open(file_path, "r") as f:
-            data = list(TracedDataCodaIO.import_coda_to_traced_data_iterable(
-                "test_user", data, "Gender", "Gender_clean", f, True))
+            TracedDataCodaIO.import_coda_to_traced_data_iterable(
+                "test_user", data, "Gender", "Gender_clean", f, True)
 
         expected_data = [
             {"URN": "+0012345000000", "Gender": "female", "Gender_clean": "F"},


### PR DESCRIPTION
Previously it was modifying the individual traced data items but returning a, identical list, which was weird. This function is now : void.