### PR TITLE
Don't Clean in Interface Export

### DIFF
--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -6,6 +6,7 @@ import jsonpickle
 import six
 from dateutil.parser import isoparse
 
+from core_data_modules.cleaners import CharacterCleaner
 from core_data_modules.traced_data import Metadata, TracedData
 
 if six.PY2:

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -6,7 +6,6 @@ import jsonpickle
 import six
 from dateutil.parser import isoparse
 
-from core_data_modules.cleaners import CharacterCleaner
 from core_data_modules.traced_data import Metadata, TracedData
 
 if six.PY2:
@@ -554,7 +553,7 @@ class TracedDataTheInterfaceIO(object):
 
     @staticmethod
     def _clean_interface_message(message):
-        return CharacterCleaner.fold_lines(CharacterCleaner.clean_text(message))
+        return message # CharacterCleaner.fold_lines(message)
 
     @staticmethod
     def _age_to_age_group(age):

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -553,7 +553,7 @@ class TracedDataTheInterfaceIO(object):
 
     @staticmethod
     def _clean_interface_message(message):
-        return message # CharacterCleaner.fold_lines(message)
+        return CharacterCleaner.fold_lines(message)
 
     @staticmethod
     def _age_to_age_group(age):

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -680,7 +680,7 @@ class TracedDataTheInterfaceIO(object):
                 }
 
                 if tag_messages:
-                    row["message"] = "{} {}".format(message_key, row["message"])
+                    row["message"] = u"{} {}".format(message_key, row["message"])
 
                 writer.writerow(row)
 

--- a/tests/traced_data/resources/the_interface_export_expected_inbox
+++ b/tests/traced_data/resources/the_interface_export_expected_inbox
@@ -1,4 +1,4 @@
 phone	date	time	message
-a	06/01/2018	10:47:02	message 1
-b	05/30/2018	21:00:00	message 2 is very long
-c	06/02/2018	18:30:02	message 3  has punctuation and non ascii    these need cleaning 
+a	06/01/2018	10:47:02	Message 1
+b	05/30/2018	21:00:00	Message 2 is very long
+c	06/02/2018	18:30:02	Message 3, has punctuation and non-ASCII: ø. These need cleaning!

--- a/tests/traced_data/resources/the_interface_export_expected_multiple_inbox
+++ b/tests/traced_data/resources/the_interface_export_expected_multiple_inbox
@@ -1,4 +1,4 @@
 phone	date	time	message
 a	06/01/2018	10:47:02	message message 1
-b	06/13/2018	00:00:00	message cd  e
+b	06/13/2018	00:00:00	message cD: øe
 a	06/01/2018	10:50:00	message message 2

--- a/tests/traced_data/resources/the_interface_export_expected_tagged_inbox
+++ b/tests/traced_data/resources/the_interface_export_expected_tagged_inbox
@@ -1,3 +1,3 @@
 phone	date	time	message
-a	06/01/2018	10:47:02	key_1 abc
-b	06/13/2018	00:00:00	key_1 cd  e
+a	06/01/2018	10:47:02	key_1 ABC
+b	06/13/2018	00:00:00	key_1 cD: øe


### PR DESCRIPTION
Previously we cleaned messages before exporting to The Interface. This was done simply to follow existing practice. However, esc4jmcna test data suggests that this is unnecessary, and analysts would prefer not to suffer the possible information loss of aggressive cleaning, so removing most of this pre-cleaning step.