### PR TITLE
Fold TracedData

### DIFF
--- a/core_data_modules/cleaners/codes/codes.py
+++ b/core_data_modules/cleaners/codes/codes.py
@@ -11,6 +11,9 @@ class Codes(object):
     URBAN = "urban"
     RURAL = "rural"
 
+    MATRIX_0 = "0"
+    MATRIX_1 = "1"
+
     STOP = "stop"
 
     TRUE_MISSING = "NA"

--- a/core_data_modules/traced_data/traced_data.py
+++ b/core_data_modules/traced_data/traced_data.py
@@ -299,7 +299,7 @@ class TracedData(Mapping):
         If there are any keys in common between TracedData items sharing the same join_on_key,
         then these keys must also have the same value in both objects.
 
-        :param user: Identifier of user running this program
+        :param user: Identifier of the user running this program, for TracedData Metadata
         :type user: str
         :param join_on_key: Key to join data on
         :type join_on_key: str
@@ -363,7 +363,7 @@ class TracedData(Mapping):
         If there are any keys in common between TracedData items sharing the same join_on_key,
         then these keys must also have the same value in both objects.
 
-        :param user: Identifier of user running this program.
+        :param user: Identifier of the user running this program, for TracedData Metadata.
         :type user: str
         :param update_id_key: Key of identifier in both iterables to match TracedData objects on.
         :type update_id_key: str

--- a/core_data_modules/traced_data/util/__init__.py
+++ b/core_data_modules/traced_data/util/__init__.py
@@ -1,0 +1,1 @@
+from .fold_traced_data import FoldTracedData

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -246,10 +246,12 @@ class FoldTracedData(object):
         return folded_td
 
     @classmethod
-    def fold_iterable_of_traced_data(cls, user, data, group_id_fn, equal_keys, concat_keys, matrix_keys, bool_keys,
+    def fold_iterable_of_traced_data(cls, user, data, fold_id_fn, equal_keys, concat_keys, matrix_keys, bool_keys,
                                      concat_delimiter=";"):
         """
-        Folds an iterable of TracedData TODO
+        Folds an iterable of TracedData into a new iterable of TracedData.
+
+        Objects with the same fold id (as determined by 'fold_id_fn') are folded together into a new TracedData object.
 
         Use the '*_keys' parameters to control how different parameters should be reconciled when folding.
         Keys not included in any of these parameters will be set to the value 'MERGED'.
@@ -258,8 +260,9 @@ class FoldTracedData(object):
         :type user: str
         :param data: TracedData objects to fold.
         :type data: iterable of TracedData
-        :param group_id_fn: TODO
-        :type group_id_fn: function of TracedData -> hashable
+        :param fold_id_fn: Function which generates a fold id for a TracedData object.
+                           TracedData objects with the same fold id will be folded into a single, new TracedData object.
+        :type fold_id_fn: function of TracedData -> hashable
         :param equal_keys: Keys to assert are equal, using FoldTracedData.assert_equal_keys_equal
         :type equal_keys: iterable of str
         :param concat_keys: Keys to fold by string concatenation, using FoldTracedData.reconcile_keys_by_concatenation.
@@ -275,7 +278,7 @@ class FoldTracedData(object):
         :rtype: iterable of TracedData
         """
         return cls.fold_groups(
-            cls.group_by(data, group_id_fn),
+            cls.group_by(data, fold_id_fn),
             lambda td_1, td_2: cls.fold_traced_data(
                 user, td_1, td_2, equal_keys, concat_keys, matrix_keys, bool_keys, concat_delimiter)
         )

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -1,0 +1,282 @@
+import time
+
+from core_data_modules.cleaners import Codes
+from core_data_modules.traced_data import Metadata
+
+
+class FoldTracedData(object):
+    @staticmethod
+    def group_by(data, group_id_fn):
+        """
+        Groups TracedData objects using the provided group id function.
+
+        :param data: TracedData objects to group.
+        :type data: iterable of TracedData
+        :param group_id_fn: Function which generates a group id for a TracedData object.
+                            TracedData objects with the same group id will be placed into the same group.
+        :type group_id_fn: function of TracedData -> hashable
+        :return: Groups of TracedData objects.
+        :rtype: iterable of iterable of TracedData
+        """
+        grouped_lut = dict()
+
+        for td in data:
+            key = group_id_fn(td)
+            if key not in grouped_lut:
+                grouped_lut[key] = []
+            grouped_lut[key].append(td)
+
+        return grouped_lut.values()
+
+    @staticmethod
+    def fold_groups(groups, fold_fn):
+        """
+        Folds the TracedData objects in each group of a list of groups using the provided fold function.
+
+        :param groups: Groups of TracedData objects. The TracedData objects in each group will be folded into a single
+                       TracedData object by repeated application of fold_fn.
+        :type groups: iterable of iterable of TracedData
+        :param fold_fn: Function to use to fold each pair of TracedData objects.
+        :type fold_fn: function of (TracedData, TracedData) -> TracedData
+        :return: Folded TracedData objects.
+        :rtype: iterable of TracedData
+        """
+        folded_data = []
+
+        for group in groups:
+            folded_td = group.pop(0)
+            while len(group) > 0:
+                folded_td = fold_fn(folded_td, group.pop(0))
+            folded_data.append(folded_td)
+
+        return folded_data
+
+    @staticmethod
+    def assert_equal_keys_equal(td_1, td_2, equal_keys):
+        """
+        Checks that the provided TracedData objects contain exactly the same values for each of the provided keys.
+
+        Raises an AssertionError if mis-matching keys are found, otherwise returns no value and has no side-effect.
+
+        :param td_1: TracedData object to check for value equality.
+        :type td_1: TracedData
+        :param td_2: TracedData object to check for value equality.
+        :type td_2: TracedData
+        :param equal_keys: Keys to check for equality in the TracedData objects.
+        :type equal_keys: iterable of str
+        """
+        for key in equal_keys:
+            assert td_1.get(key) == td_2.get(key), "Key '{}' should be the same in both td_1 and td_2 but is " \
+                                                   "different (has values '{}' and '{}' " \
+                                                   "respectively)".format(key, td_1.get(key), td_2.get(key))
+
+    @staticmethod
+    def reconcile_keys_by_concatenation(user, td_1, td_2, keys, concat_delimiter=";"):
+        """
+        Sets the given keys in two TracedData objects to the same value by string concatenating the values of each.
+
+        Concatenated values take the form <td_1[key]><concat_delimiter><td_2[key]>.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param td_1: First TracedData object to concatenate the keys with.
+                     This value will appear first in the concatenated string i.e. before the concat_delimiter.
+        :type td_1: TracedData
+        :param td_2: Second TracedData object to concatenate the keys with.
+                     This value will appear first in the concatenated string i.e. after the concat_delimiter.
+        :type td_2: TracedData
+        :param keys: Keys in each TracedData object to concatenate the values of.
+        :type keys: iterable of str
+        :param concat_delimiter: String to separate the concatenated strings with.
+        :type concat_delimiter: str
+        """
+        concat_dict = dict()
+
+        for key in keys:
+            if key in td_1 and key in td_2:
+                concat_dict[key] = "{}{}{}".format(td_1[key], concat_delimiter, td_2[key])
+
+        td_1.append_data(concat_dict, Metadata(user, Metadata.get_call_location(), time.time()))
+        td_2.append_data(concat_dict, Metadata(user, Metadata.get_call_location(), time.time()))
+
+    @staticmethod
+    def reconcile_matrix_keys(user, td_1, td_2, keys):
+        """
+        Sets given keys in two TracedData objects to the same value, of Codes.MATRIX_1 if the value in either
+        of those objects is Codes.MATRIX_1, otherwise sets the values to Codes.MATRIX_0.
+
+        An exception is made for keys ending with Codes.NOT_CODED - in this case, the folded value is Codes.MATRIX_0
+        unless the value in both td_1 and td_2 is Codes.MATRIX_1.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param td_1: TracedData object to reconcile the matrix keys of.
+        :type td_1: TracedData
+        :param td_2: TracedData object to reconcile the matrix keys of.
+        :type td_2: TracedData
+        :param keys: Keys in each TracedData object to reconcile.
+        :type keys: iterable of str
+        """
+        matrix_dict = dict()
+
+        possible_matrix_values = {Codes.MATRIX_0, Codes.MATRIX_1}
+        for key in keys:
+            if td_1.get(key) == Codes.STOP or td_2.get(key) == Codes.STOP:
+                matrix_dict[key] = Codes.STOP
+                continue
+
+            # TODO: Handle the different modes of missing data
+
+            if key.endswith(Codes.NOT_CODED):
+                if td_1.get(key) == Codes.MATRIX_0 or td_2.get(key) == Codes.MATRIX_0:
+                    matrix_dict[key] = Codes.MATRIX_0
+                else:
+                    matrix_dict[key] = Codes.MATRIX_1
+                continue
+
+            assert td_1.get(key) in possible_matrix_values, \
+                "td_1.get('{}') is not '{}' or '{}' (has value '{}')".format(
+                    key, Codes.MATRIX_0, Codes.MATRIX_1, td_1.get(key))
+            assert td_2.get(key) in possible_matrix_values, \
+                "td_2.get('{}') is not '{}' or '{}' (has value '{}')".format(
+                    key, Codes.MATRIX_0, Codes.MATRIX_1, td_2.get(key))
+
+            if td_1.get(key) == Codes.MATRIX_1 or td_2.get(key) == Codes.MATRIX_1:
+                matrix_dict[key] = Codes.MATRIX_1
+            else:
+                matrix_dict[key] = Codes.MATRIX_0
+
+        td_1.append_data(matrix_dict, Metadata(user, Metadata.get_call_location(), time.time()))
+        td_2.append_data(matrix_dict, Metadata(user, Metadata.get_call_location(), time.time()))
+
+    @staticmethod
+    def reconcile_boolean_keys(user, td_1, td_2, keys):
+        """
+        Sets the given keys in two TracedData objects to the same value, of Codes.TRUE if the value in either
+        of those objects is Codes.TRUE, otherwise sets the values to Codes.FALSE.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param td_1: TracedData object to reconcile the boolean keys of.
+        :type td_1: TracedData
+        :param td_2: TracedData object to reconcile the boolean keys of.
+        :type td_2: TracedData
+        :param keys: Keys in each TracedData object to reconcile.
+        :type keys: iterable of str
+        """
+        bool_dict = dict()
+
+        for key in keys:
+            if td_1.get(key) == Codes.TRUE or td_2.get(key) == Codes.TRUE:
+                bool_dict[key] = Codes.TRUE
+            else:
+                bool_dict[key] = Codes.FALSE
+
+        td_1.append_data(bool_dict, Metadata(user, Metadata.get_call_location(), time.time()))
+        td_2.append_data(bool_dict, Metadata(user, Metadata.get_call_location(), time.time()))
+
+    # TODO: Support reconciling datetime strings
+
+    # TODO: Support reconciling yes/no codes
+
+    @staticmethod
+    def set_keys_to_value(user, td, keys, value="MERGED"):
+        """
+        Sets the given keys in a TracedData object to the same given value.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param td: TracedData object to set the keys of.
+        :type td: TracedData
+        :param keys: Keys to set.
+        :type keys: iterable of str
+        :param value: Value to set each key to.
+        :type value: str
+        """
+        td.append_data({key: value for key in keys}, Metadata(user, Metadata.get_call_location(), time.time()))
+
+    @classmethod
+    def fold_traced_data(cls, user, td_1, td_2, equal_keys, concat_keys, matrix_keys, bool_keys, concat_delimiter=";"):
+        # TODO: Make all of the *_keys arguments optional (defaulting to empty set)
+        """
+        Folds two TracedData object into a new TracedData object.
+
+        Use the '*_keys' parameters to control how different parameters should be reconciled when folding.
+        Keys not included in any of these parameters will be set to the value 'MERGED'.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param td_1: First TracedData object to fold.
+        :type td_1: TracedData
+        :param td_2: Second TracedData object to fold.
+        :type td_2: TracedData
+        :param equal_keys: Keys to assert are equal, using FoldTracedData.assert_equal_keys_equal
+        :type equal_keys: iterable of str
+        :param concat_keys: Keys to fold by string concatenation, using FoldTracedData.reconcile_keys_by_concatenation.
+                            Concatenated values take the form <td_1[key]><concat_delimiter><td_2[key]>.
+        :type concat_keys: iterable of str
+        :param matrix_keys: Keys to fold using FoldTracedData.reconcile_matrix_keys.
+        :type matrix_keys: iterable of str
+        :param bool_keys: Boolean keys, to fold using FoldTracedData.reconcile_boolean_keys.
+        :type bool_keys: iterable of str
+        :param concat_delimiter: String to separate the concatenated strings with.
+        :type concat_delimiter: str
+        :return: td_1 folded with td_2.
+        :rtype: TracedData
+        """
+        td_1 = td_1.copy()
+        td_2 = td_2.copy()
+
+        cls.assert_equal_keys_equal(td_1, td_2, equal_keys)
+        cls.reconcile_keys_by_concatenation(user, td_1, td_2, concat_keys, concat_delimiter)
+        cls.reconcile_matrix_keys(user, td_1, td_2, matrix_keys)
+        cls.reconcile_boolean_keys(user, td_1, td_2, bool_keys)
+
+        equal_keys = set(equal_keys)
+        equal_keys.update(concat_keys)
+        equal_keys.update(matrix_keys)
+        equal_keys.update(bool_keys)
+
+        cls.set_keys_to_value(user, td_1, set(td_1.keys()) - set(equal_keys))
+        cls.set_keys_to_value(user, td_2, set(td_2.keys()) - set(equal_keys))
+
+        folded_td = td_1
+        folded_td.append_traced_data("folded_with", td_2, Metadata(user, Metadata.get_call_location(), time.time()))
+
+        return folded_td
+
+    @classmethod
+    def fold_iterable_of_traced_data(cls, user, data, group_id_fn, equal_keys, concat_keys, matrix_keys, bool_keys,
+                                     concat_delimiter=";"):
+        """
+        Folds an iterable of TracedData TODO
+
+        Use the '*_keys' parameters to control how different parameters should be reconciled when folding.
+        Keys not included in any of these parameters will be set to the value 'MERGED'.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to fold.
+        :type data: iterable of TracedData
+        :param group_id_fn: TODO
+        :type group_id_fn: function of TracedData -> hashable
+        :param equal_keys: Keys to assert are equal, using FoldTracedData.assert_equal_keys_equal
+        :type equal_keys: iterable of str
+        :param concat_keys: Keys to fold by string concatenation, using FoldTracedData.reconcile_keys_by_concatenation.
+                            Concatenated values take the form <td_1[key]><concat_delimiter><td_2[key]>.
+        :type concat_keys: iterable of str
+        :param matrix_keys: Keys to fold using FoldTracedData.reconcile_matrix_keys.
+        :type matrix_keys: iterable of str
+        :param bool_keys: Boolean keys, to fold using FoldTracedData.reconcile_boolean_keys.
+        :type bool_keys: iterable of str
+        :param concat_delimiter: String to separate the concatenated strings with.
+        :type concat_delimiter: str
+        :return: Folded TracedData objects.
+        :rtype: iterable of TracedData
+        """
+        return cls.fold_groups(
+            cls.group_by(data, group_id_fn),
+            lambda td_1, td_2: cls.fold_traced_data(
+                user, td_1, td_2, equal_keys, concat_keys, matrix_keys, bool_keys, concat_delimiter)
+        )
+

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -1,0 +1,210 @@
+import unittest
+
+from core_data_modules.cleaners import Codes
+from core_data_modules.traced_data import Metadata, TracedData
+from core_data_modules.traced_data.util import FoldTracedData
+
+
+class TestFoldTracedData(unittest.TestCase):
+    @staticmethod
+    def make_traced_data(dicts, start_time=0):
+        return [TracedData(d, Metadata("test_user", Metadata.get_call_location(), i + start_time))
+                for i, d in enumerate(dicts)]
+
+    def test_group_by(self):
+        flat_dicts = [
+            {"id": "a", "x": "4"},
+            {"id": "b", "x": "5"},
+            {"id": "a", "x": "6"},
+            {"id": "a", "x": "7"},
+            {"id": "c", "x": "8"},
+            {"id": "b", "x": "9"}
+        ]
+
+        flat_data = self.make_traced_data(flat_dicts)
+
+        grouped = list(FoldTracedData.group_by(flat_data, lambda td: td["id"]))
+
+        self.assertEqual(len(grouped), 3)
+
+        grouped.sort(key=lambda l: l[0]["id"])
+        self.assertListEqual([td["x"] for td in grouped[0]], ["4", "6", "7"])
+        self.assertListEqual([td["x"] for td in grouped[1]], ["5", "9"])
+        self.assertListEqual([td["x"] for td in grouped[2]], ["8"])
+
+    def test_fold_groups(self):
+        data = [TracedData({"x": c}, Metadata("test_user", Metadata.get_call_location(), i))
+                for i, c in enumerate(["a", "b", "c", "d", "e"])]
+
+        groups = [
+            [data[0]],
+            [data[1], data[2], data[3]],
+            [data[4]]
+        ]
+
+        def fold_fn(td_1, td_2):
+            td_1 = td_1.copy()
+            td_2 = td_2.copy()
+
+            folded_dict = {"x": "{}{}".format(td_1["x"], td_2["x"])}
+
+            td_1.append_data(folded_dict, Metadata("test_user", Metadata.get_call_location(), 10))
+            td_2.append_data(folded_dict, Metadata("test_user", Metadata.get_call_location(), 11))
+
+            folded = td_1
+            td_1.append_traced_data("folded_with", td_2, Metadata("test_user", Metadata.get_call_location(), 12))
+
+            return folded
+
+        folded_data = FoldTracedData.fold_groups(groups, fold_fn)
+
+        self.assertDictEqual(dict(folded_data[0].items()), {"x": "a"})
+        self.assertDictEqual(dict(folded_data[1].items()), {"x": "bcd"})
+        self.assertDictEqual(dict(folded_data[2].items()), {"x": "e"})
+
+    def test_assert_equal_keys_equal(self):
+        td_1 = TracedData(
+            {"eq1": "5", "eq2": "6", "ne": "10"},
+            Metadata("test_user", Metadata.get_call_location(), 0)
+        )
+
+        td_2_expect_pass = TracedData(
+            {"eq1": "5", "eq2": "6", "ne": "13"},
+            Metadata("test_user", Metadata.get_call_location(), 1)
+        )
+
+        td_2_expect_fail = TracedData(
+            {"eq1": "5", "eq2": "7", "ne": "10"},
+            Metadata("test_user", Metadata.get_call_location(), 1)
+        )
+
+        # This test is considered successful if no assertion is raised
+        FoldTracedData.assert_equal_keys_equal(td_1, td_2_expect_pass, {"eq1", "eq2"})
+
+        try:
+            FoldTracedData.assert_equal_keys_equal(td_1, td_2_expect_fail, {"eq1", "eq2"})
+            self.fail("No AssertionError raised")
+        except AssertionError as e:
+            if str(e) == "No AssertionError raised":
+                raise e
+
+            self.assertEqual(str(e),
+                             "Key 'eq2' should be the same in both td_1 and td_2 but is "
+                             "different (has values '6' and '7' respectively)")
+
+    def test_reconcile_keys_by_concatenation(self):
+        def make_tds():
+            td_1 = TracedData(
+                {"msg1": "abc", "msg2": "xy", "x": 4},
+                Metadata("test_user", Metadata.get_call_location(), 0)
+            )
+
+            td_2 = TracedData(
+                {"msg1": "def", "msg2": "xy", "x": 5},
+                Metadata("test_user", Metadata.get_call_location(), 1)
+            )
+
+            return td_1, td_2
+
+        td_1, td_2 = make_tds()
+        FoldTracedData.reconcile_keys_by_concatenation("test_user", td_1, td_2, {"msg1", "msg2"})
+        self.assertDictEqual(dict(td_1.items()), {"msg1": "abc;def", "msg2": "xy;xy", "x": 4})
+        self.assertDictEqual(dict(td_2.items()), {"msg1": "abc;def", "msg2": "xy;xy", "x": 5})
+
+        td_1, td_2 = make_tds()
+        FoldTracedData.reconcile_keys_by_concatenation("test_user", td_1, td_2, {"msg1", "msg2"}, concat_delimiter="--")
+        self.assertDictEqual(dict(td_1.items()), {"msg1": "abc--def", "msg2": "xy--xy", "x": 4})
+        self.assertDictEqual(dict(td_2.items()), {"msg1": "abc--def", "msg2": "xy--xy", "x": 5})
+
+    def test_reconcile_matrix_keys(self):
+        td_1 = TracedData(
+            {"a": Codes.MATRIX_0, "b": Codes.MATRIX_1, Codes.NOT_REVIEWED: Codes.MATRIX_1,
+             Codes.NOT_CODED: Codes.MATRIX_1, "c": Codes.STOP},
+            Metadata("test_user", Metadata.get_call_location(), 0)
+        )
+
+        td_2 = TracedData(
+            {"a": Codes.MATRIX_0, "b": Codes.MATRIX_0, Codes.NOT_REVIEWED: Codes.MATRIX_0,
+             Codes.NOT_CODED: Codes.MATRIX_0, "c": Codes.MATRIX_0},
+            Metadata("test_user", Metadata.get_call_location(), 1)
+        )
+
+        # TODO: Update dictionaries above to test for the various cases of missing data
+
+        FoldTracedData.reconcile_matrix_keys("test_user", td_1, td_2, td_1.keys())
+
+        expected_dict = {"a": Codes.MATRIX_0, "b": Codes.MATRIX_1, Codes.NOT_REVIEWED: Codes.MATRIX_1,
+                         Codes.NOT_CODED: Codes.MATRIX_0, "c": Codes.STOP}
+        self.assertDictEqual(dict(td_1.items()), expected_dict)
+        self.assertDictEqual(dict(td_2.items()), expected_dict)
+
+    def test_reconcile_boolean_keys(self):
+        td_1 = TracedData(
+            {"a": Codes.TRUE, "b": Codes.FALSE, "c": Codes.FALSE, "d": Codes.NOT_CODED, "e": Codes.NOT_CODED},
+            Metadata("test_user", Metadata.get_call_location(), 0)
+        )
+
+        td_2 = TracedData(
+            {"a": Codes.TRUE, "b": Codes.TRUE, "c": Codes.FALSE, "d": Codes.TRUE, "e": Codes.NOT_CODED},
+            Metadata("test_user", Metadata.get_call_location(), 1)
+        )
+
+        FoldTracedData.reconcile_boolean_keys("test_user", td_1, td_2, {"a", "b", "c", "d", "e"})
+
+        expected_dict = {"a": Codes.TRUE, "b": Codes.TRUE, "c": Codes.FALSE, "d": Codes.TRUE, "e": Codes.FALSE}
+        self.assertDictEqual(dict(td_1.items()), expected_dict)
+        self.assertDictEqual(dict(td_2.items()), expected_dict)
+
+    def test_set_keys_to_value(self):
+        td = TracedData(
+            {"msg1": "abc", "msg2": "xy", "x": 4},
+            Metadata("test_user", Metadata.get_call_location(), 0)
+        )
+
+        FoldTracedData.set_keys_to_value("test_user", td, {"msg1"})
+        self.assertDictEqual(dict(td.items()), {"msg1": "MERGED", "msg2": "xy", "x": 4})
+
+        FoldTracedData.set_keys_to_value("test_user", td, {"msg2", "x"}, value="----")
+        self.assertDictEqual(dict(td.items()), {"msg1": "MERGED", "msg2": "----", "x": "----"})
+
+    def test_fold_td(self):
+        td_1_dict = {
+                "equal_1": 4, "equal_2": "xyz",
+                "concat": "abc",
+                "matrix_1": Codes.MATRIX_0, "matrix_2": Codes.STOP,
+                "bool_1": Codes.FALSE, "bool_2": Codes.TRUE,
+                "other_1": "other 1", "other_2": "other 2"
+             }
+
+        td_2_dict = {
+                "equal_1": 4, "equal_2": "xyz",
+                "concat": "def",
+                "matrix_1": Codes.MATRIX_1, "matrix_2": Codes.MATRIX_0,
+                "bool_1": Codes.TRUE, "bool_2": Codes.TRUE,
+                "other_1": "other",
+            }
+
+        td_1 = TracedData(td_1_dict, Metadata("test_user", Metadata.get_call_location(), 0))
+        td_2 = TracedData(td_2_dict, Metadata("test_user", Metadata.get_call_location(), 1))
+
+        folded_td = FoldTracedData.fold_traced_data(
+            "test_user", td_1, td_2, equal_keys={"equal_1", "equal_2"}, concat_keys={"concat"},
+            matrix_keys={"matrix_1", "matrix_2"}, bool_keys={"bool_1", "bool_2"},
+            concat_delimiter=". "
+        )
+
+        # Test input tds unchanged
+        self.assertDictEqual(dict(td_1.items()), td_1_dict)
+        self.assertDictEqual(dict(td_2.items()), td_2_dict)
+
+        # Test folded td has expected values
+        self.assertDictEqual(
+            dict(folded_td.items()),
+            {
+                "equal_1": 4, "equal_2": "xyz",
+                "concat": "abc. def",
+                "matrix_1": Codes.MATRIX_1, "matrix_2": Codes.STOP,
+                "bool_1": Codes.TRUE, "bool_2": Codes.TRUE,
+                "other_1": "MERGED", "other_2": "MERGED"
+            }
+        )


### PR DESCRIPTION
Adds FoldTracedData utility functions. 

The code is taken from the FoldData class from REACH (original PR here: https://github.com/AfricasVoices/REACH/pull/6/files), with very minor refactoring and the addition of unit tests. More work is likely to be needed in order to generalise this to future projects; I have used TODOs to identify some of the most obvious cases where this is still falling short.