### PR TITLE
Correct Scheme/Code not equals implementation

### DIFF
--- a/core_data_modules/data_models/scheme.py
+++ b/core_data_modules/data_models/scheme.py
@@ -21,7 +21,7 @@ class Scheme(object):
             other.documentation == self.documentation and \
             other.codes == self.codes
     
-    def __neq__(self, other):
+    def __ne__(self, other):
         return not self.__eq__(other)
 
     def get_code_with_id(self, code_id):
@@ -152,5 +152,5 @@ class Code:
             other.visible_in_coda == self.visible_in_coda & \
             other.color == self.color
     
-    def __neq__(self, other):
+    def __ne__(self, other):
         return not self.__eq__(other)


### PR DESCRIPTION
__neq__ is not a function in Python.

The pipelines haven't been impacted by this because Python 3 will automatically use __eq__ to define __ne__ if no definition of __ne__ is provided. This is not true of Python 2, however.