### PR TITLE
Validate UTC Strings

### DIFF
--- a/core_data_modules/data_models/message.py
+++ b/core_data_modules/data_models/message.py
@@ -62,8 +62,7 @@ class Message(object):
     def validate(self):
         validators.validate_string(self.message_id, "message_id")
         validators.validate_string(self.text, "text")
-        validators.validate_string(self.creation_date_time_utc, "creation_date_time_utc")
-        # TODO: Validate that creation_date_time_utc is an ISO format string?
+        validators.validate_utc_iso_string(self.creation_date_time_utc, "creation_date_time_utc")
         validators.validate_list(self.labels, "labels")
 
         for i, label in enumerate(self.labels):
@@ -133,8 +132,7 @@ class Label(object):
     def validate(self):
         validators.validate_string(self.scheme_id, "scheme_id")
         validators.validate_string(self.code_id, "code_id")
-        validators.validate_string(self.date_time_utc, "date_time_utc")
-        # TODO: Validate that date_time_utc is an ISO format string?
+        validators.validate_utc_iso_string(self.date_time_utc, "date_time_utc")
 
         if self.checked is not None:
             validators.validate_bool(self.checked, "checked")

--- a/core_data_modules/data_models/validators.py
+++ b/core_data_modules/data_models/validators.py
@@ -1,3 +1,6 @@
+from dateutil.parser import isoparse
+
+
 def validate_string(s, variable_name=""):
     assert isinstance(s, str), "{} not a string".format(variable_name)
     assert s != "", "{} is empty".format(variable_name)
@@ -27,3 +30,18 @@ def validate_list(l, variable_name=""):
 def validate_dict(d, variable_name=""):
     assert isinstance(d, dict), "{} not a dict".format(variable_name)
     return d
+
+
+def validate_iso_string(s, variable_name=""):
+    validate_string(s, variable_name)
+    try:
+        isoparse(s)
+    except:
+        assert False, "{} not an ISO string".format(variable_name)
+    return s
+
+
+def validate_utc_iso_string(s, variable_name=""):
+    validate_iso_string(s, variable_name)
+    assert s.endswith("Z") or s.endswith("+00:00"), "{} not a UTC ISO string".format(variable_name)
+    return s

--- a/tests/cleaners/data_models/test_validators.py
+++ b/tests/cleaners/data_models/test_validators.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+import unittest
+
+from core_data_modules.data_models import validators
+
+
+class TestValidators(unittest.TestCase):
+    def _expect_validation_failure(self, f, expected_assertion_error_message):
+        try:
+            f()
+        except AssertionError as e:
+            assert str(e) == expected_assertion_error_message
+            return
+
+        self.fail("Invalid data passed validation")
+
+    def test_validate_string(self):
+        validators.validate_string("Test")
+        validators.validate_string("åø")
+
+        self._expect_validation_failure(lambda: validators.validate_string(4), " not a string")
+        
+    def test_validate_iso_string(self):
+        validators.validate_iso_string("2018")
+        validators.validate_iso_string("2018-11-10T13:00:00")
+        validators.validate_iso_string("2018-11-10T13:00Z")
+        validators.validate_iso_string("2018-11-10T13:00:05+00:00")
+        validators.validate_iso_string("2018-11-10T13:00:05+03:00")
+
+        self._expect_validation_failure(lambda: validators.validate_iso_string("5/12/2018"), " not an ISO string")
+        self._expect_validation_failure(lambda: validators.validate_iso_string("05/12/2018"), " not an ISO string")
+        self._expect_validation_failure(lambda: validators.validate_iso_string("2018-11-1013:00"), " not an ISO string")
+
+    def test_validate_utc_iso_string(self):
+        validators.validate_utc_iso_string("2018-11-10T13:00:05Z")
+        validators.validate_utc_iso_string("2018-11-10T13:00:05+00:00")
+
+        self._expect_validation_failure(
+            lambda: validators.validate_utc_iso_string("2018-11-10T13:00:00"), " not a UTC ISO string")
+
+        self._expect_validation_failure(
+            lambda: validators.validate_utc_iso_string("2018-11-10T13:00:05+03:00"), " not a UTC ISO string")


### PR DESCRIPTION
It's too easy to forget to do the timezone conversion to not be validating this.

I wonder it if it might also be worth modifying the constructors to Message and Label to accept strings in any timezone, and pushing the utc-conversion code into the constructors?