### PR TITLE
Deserialize on Coda 2 Import

### DIFF
--- a/core_data_modules/data_models/message.py
+++ b/core_data_modules/data_models/message.py
@@ -129,6 +129,10 @@ class Label(object):
     def to_dict(self):
         return self.to_firebase_map()
 
+    @classmethod
+    def from_dict(cls, d):
+        return cls.from_firebase_map(d)
+
     def validate(self):
         validators.validate_string(self.scheme_id, "scheme_id")
         validators.validate_string(self.code_id, "code_id")

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -242,7 +242,9 @@ class TracedDataCodaV2IO(object):
         :rtype: dict of str -> (dict of str -> list of Label)
         """
         coda_messages_file = json.load(f)
-        messages = [Message.from_firebase_map(m) for m in coda_messages_file]
+        messages = []
+        for json_msg in coda_messages_file:
+            messages.append(Message.from_firebase_map(json_msg))
 
         dataset_lut = dict()  # of MessageID -> (dict of SchemeID -> list of Label)
         for msg in messages:

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -255,9 +255,7 @@ class TracedDataCodaV2IO(object):
             schemes_lut = dict()  # of SchemeID -> list of Label (for this message)
             dataset_lut[msg.message_id] = schemes_lut
 
-            labels = list(msg.labels)
-            labels.reverse()  # Coda outputs most-recent first but easier to handle in Python if most-recent last
-            for label in labels:
+            for label in msg.labels:
                 for scheme_to_parse in schemes_to_parse:
                     if label.scheme_id == scheme_to_parse.scheme_id or label.scheme_id.startswith(scheme_to_parse.scheme_id):
                         primary_scheme_id = scheme_to_parse.scheme_id
@@ -308,7 +306,7 @@ class TracedDataCodaV2IO(object):
                 labels = coda_dataset.get(td[message_id_key], dict()).get(scheme.scheme_id, [])
                 if labels is not None:
                     # Append each label that was assigned to this message for this scheme to the TracedData.
-                    for label in labels:
+                    for label in reversed(labels):
                         td.append_data({key_of_coded: label.to_dict()},
                                        Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
@@ -373,7 +371,7 @@ class TracedDataCodaV2IO(object):
                 td_labels = td.get(coded_key, [])
                 td_labels_lut = {label["SchemeID"]: Label.from_dict(label) for label in td_labels}
 
-                for label in labels:
+                for label in reversed(labels):
                     # Update the relevant label in this traced data's list of labels with the new label,
                     # and append the whole new list to the traced data.
                     td_labels_lut[label.scheme_id] = label

--- a/tests/traced_data/resources/coda_2_import_test_multi_coded.json
+++ b/tests/traced_data/resources/coda_2_import_test_multi_coded.json
@@ -70,6 +70,42 @@
         },
         "Confidence": 1,
         "Checked": true
+      },
+      {
+        "SchemeID": "Scheme-c4855fcb-2",
+        "Origin": {
+          "Name": "test_user",
+          "OriginID": "test_user_id",
+          "OriginType": "Manual"
+        },
+        "Confidence": 1,
+        "Checked": false,
+        "CodeID": "SPECIAL-MANUALLY_UNCODED",
+        "DateTimeUTC": "2019-01-25T11:14:07.746Z"
+      },
+      {
+        "Origin": {
+          "Name": "test_user",
+          "OriginID": "test_user_id",
+          "OriginType": "Manual"
+        },
+        "Confidence": 1,
+        "Checked": true,
+        "CodeID": "code-NC-42f1d983",
+        "DateTimeUTC": "2019-01-25T11:14:06.117Z",
+        "SchemeID": "Scheme-c4855fcb-2"
+      },
+      {
+        "Origin": {
+          "Name": "test_user",
+          "OriginID": "test_user_id",
+          "OriginType": "Manual"
+        },
+        "Confidence": 1,
+        "Checked": true,
+        "CodeID": "code-88433f94",
+        "DateTimeUTC": "2019-01-25T11:14:03.763Z",
+        "SchemeID": "Scheme-c4855fcb"
       }
     ],
     "Text": "food + water",

--- a/tests/traced_data/resources/coda_2_import_test_one_scheme.json
+++ b/tests/traced_data/resources/coda_2_import_test_one_scheme.json
@@ -97,6 +97,18 @@
         "SchemeID": "Scheme-12cb6f95"
       },
       {
+        "Origin": {
+          "Name": "Test User",
+          "OriginID": "test_user",
+          "OriginType": "Manual"
+        },
+        "Confidence": 1,
+        "Checked": true,
+        "CodeID": "code-63dcde9a",
+        "DateTimeUTC": "2018-12-13T17:42:35.874Z",
+        "SchemeID": "Scheme-12cb6f95"
+      },
+      {
         "Checked": false,
         "CodeID": "code-86a4602c",
         "DateTimeUTC": "2018-11-02T15:00:07.000Z",


### PR DESCRIPTION
Doing this means:
 - The validators will be run when we import a Coda file.
 - Labels are read by the order in which they were assigned, not by timestamp.

There are also some longer histories in the test files now, including non-sequential timestamps.