### PR TITLE
Remove NA/NS checks from TracedDataCodaV2IO

### DIFF
--- a/core_data_modules/cleaners/cleaning_utils.py
+++ b/core_data_modules/cleaners/cleaning_utils.py
@@ -1,7 +1,4 @@
 import time
-from datetime import datetime
-
-import pytz
 
 from core_data_modules.cleaners import Codes
 from core_data_modules.data_models import Origin, Label
@@ -41,8 +38,6 @@ class CleaningUtils(object):
         """
         Applies a cleaning function to an iterable of TracedData objects, updating each with a new Label object.
 
-        TracedData objects which have already been coded as TRUE_MISSING or SKIPPED in `clean_key` are not cleaned.
-        
         :param user: Identifier of the user running this program, for TracedData Metadata.
         :type user: str
         :param data: TracedData objects to apply the cleaner to.
@@ -50,10 +45,6 @@ class CleaningUtils(object):
         :param raw_key: Key in each TracedData object of the raw text to be cleaned.
         :type raw_key: str
         :param clean_key: Key in each TracedData object to write cleaned labels to.
-                          These keys may already be present in TracedData objects. In such cases:
-                           - Keys which have been labelled as TRUE_MISSING or SKIPPED under this scheme are
-                             left untouched.
-                           - All other keys are overwritten with new codes.
         :type clean_key: str
         :param cleaner: Cleaning function to apply to each TracedData[`raw_key`].
         :type cleaner: function of str -> str
@@ -61,11 +52,10 @@ class CleaningUtils(object):
         :type scheme: Scheme
         """
         for td in data:
-            # Don't re-clean data which has already been coded as missing
-            if td.get(clean_key) is not None and \
-                    scheme.get_code_with_id(td[clean_key]["CodeID"]).control_code in {Codes.TRUE_MISSING, Codes.SKIPPED}:
+            # Skip data that isn't present
+            if raw_key not in td:
                 continue
-
+           
             clean_value = cleaner(td[raw_key])
 
             # Don't label data which the cleaners couldn't code

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -201,7 +201,7 @@ class TracedDataCodaV2IO(object):
 
         cls._assert_uniquely_coded(data, message_id_key, scheme_key_map.keys())
         data = cls._filter_duplicates(data, message_id_key, creation_date_time_key)
-        data = cls._filter_missing(data, scheme_key_map)
+        # data = cls._filter_missing(data, scheme_key_map)
 
         coda_messages = []  # List of Coda V2 Message objects to be exported
         for td in data:

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -124,10 +124,11 @@ class TracedDataCodaV2IO(object):
 
         Data is de-duplicated on export.
 
-        TracedData objects which do not contain the given raw_key, or which the value at raw_key is empty string,
-        will not have data exported.
+        This function will not export data objects which do not contain the raw_key, or for which the value at the
+        raw_key is an empty string.
         Data which has been coded as NOT_CODED will be exported but without the NOT_CODED label.
-        TracedData objects with the same message id must have the same labels applied, otherwise this exporter will fail.
+        TracedData objects with the same message id must have the same labels applied, otherwise this exporter will
+        fail.
 
         :param data: Data to export to Coda V2.
         :type data: iterable of TracedData

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -196,7 +196,7 @@ class TracedDataCodaV2IO(object):
         :param f: File to write exported JSON file to.
         :type f: file-like
         """
-        # Filter data for elements which contain the given raw key
+        # Filter data for elements which contain a value for the given raw key that isn't empty string
         data = [td for td in data if td.get(raw_key, "") != ""]
 
         cls._assert_uniquely_coded(data, message_id_key, scheme_key_map.keys())
@@ -300,11 +300,9 @@ class TracedDataCodaV2IO(object):
                         td.append_data({key_of_coded: label},
                                        Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
-                # If no label, or the label is a non-missing label that hasn't been checked, set a code for NOT_REVIEWED
-                if key_of_coded not in td or (
-                       not td[key_of_coded]["Checked"] and
-                       td[key_of_coded]["CodeID"] != scheme.get_code_with_control_code(Codes.SKIPPED).code_id and
-                       td[key_of_coded]["CodeID"] != scheme.get_code_with_control_code(Codes.TRUE_MISSING).code_id):
+                # If this td still has no label after importing from the Coda file, or the label is a non-missing label
+                # that hasn't been checked in the Coda UI, set a code for NOT_REVIEWED
+                if key_of_coded not in td or not td[key_of_coded]["Checked"]:
                     nr_label = CleaningUtils.make_label_from_cleaner_code(
                         scheme, scheme.get_code_with_control_code(Codes.NOT_REVIEWED),
                         Metadata.get_call_location()

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -197,7 +197,7 @@ class TracedDataCodaV2IO(object):
         :type f: file-like
         """
         # Filter data for elements which contain the given raw key
-        data = [td for td in data if raw_key in td]
+        data = [td for td in data if td.get(raw_key, "") != ""]
 
         cls._assert_uniquely_coded(data, message_id_key, scheme_key_map.keys())
         data = cls._filter_duplicates(data, message_id_key, creation_date_time_key)

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -385,16 +385,13 @@ class TracedDataCodaV2IO(object):
                 # If no manual labels have been set, or not all of the labels are TRUE_MISSING or SKIPPED,
                 # set a label for NOT_REVIEWED.
                 checked_codes_count = 0
-                coded_as_missing = False
                 labels = td.get(coded_key)
                 if labels is not None:
                     for label in labels:
                         if label["Checked"]:
                             checked_codes_count += 1
-                    coded_as_missing = cls._is_coded_as_missing(
-                        [scheme.get_code_with_id(label["CodeID"]).control_code for label in labels])
 
-                if checked_codes_count == 0 and not coded_as_missing:
+                if checked_codes_count == 0:
                     nr_label = CleaningUtils.make_label_from_cleaner_code(
                         scheme, scheme.get_code_with_control_code(Codes.NOT_REVIEWED),
                         Metadata.get_call_location()

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -145,13 +145,13 @@ class TracedDataCodaV2IO(object):
         :type f: file-like
         """
         # Filter data for elements which contain a value for the given raw key that isn't empty string
-        data = [td for td in data if td.get(raw_key, "") != ""]
+        filtered_data = [td for td in data if td.get(raw_key, "") != ""]
 
-        cls._assert_uniquely_coded(data, message_id_key, scheme_key_map.keys())
-        data = cls._filter_duplicates(data, message_id_key, creation_date_time_key)
+        cls._assert_uniquely_coded(filtered_data, message_id_key, scheme_key_map.keys())
+        filtered_data = cls._filter_duplicates(filtered_data, message_id_key, creation_date_time_key)
 
         coda_messages = []  # List of Coda V2 Message objects to be exported
-        for td in data:
+        for td in filtered_data:
             # Export labels for this row which are not Codes.NOT_CODED
             labels = []
             for coded_key, scheme in scheme_key_map.items():

--- a/tests/traced_data/test_io.py
+++ b/tests/traced_data/test_io.py
@@ -71,18 +71,6 @@ class TestTracedDataCodaV2IO(unittest.TestCase):
         with open("tests/traced_data/resources/coda_2_gender_scheme.json") as f:
             gender_scheme = Scheme.from_firebase_map(json.load(f))
 
-        # Set TRUE_MISSING codes
-        for td in messages:
-            na_label = CleaningUtils.make_label_from_cleaner_code(
-                gender_scheme,
-                gender_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
-                "test_export_traced_data_iterable_to_coda_2",
-                date_time_utc="2018-11-02T10:00:00+00:00"
-            )
-            if td.get("gender_raw", "") == "":
-                td.append_data({"gender_coded": na_label.to_dict()},
-                               Metadata("test_user", Metadata.get_call_location(), time.time()))
-
         # Apply the English gender cleaner
         with mock.patch("core_data_modules.util.TimeUtils.utc_now_as_iso_string") as time_mock, \
                 mock.patch("core_data_modules.traced_data.Metadata.get_function_location") as location_mock:
@@ -113,6 +101,19 @@ class TestTracedDataCodaV2IO(unittest.TestCase):
 
         na_id = gender_scheme.get_code_with_control_code(Codes.TRUE_MISSING).code_id
         nr_id = gender_scheme.get_code_with_control_code(Codes.NOT_REVIEWED).code_id
+
+        # Set TRUE_MISSING codes
+        for td in imported_messages:
+            na_label = CleaningUtils.make_label_from_cleaner_code(
+                gender_scheme,
+                gender_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
+                "test_export_traced_data_iterable_to_coda_2",
+                date_time_utc="2018-11-02T10:00:00+00:00"
+            )
+            if td.get("gender_raw", "") == "":
+                td.append_data({"gender_coded": na_label.to_dict()},
+                               Metadata("test_user", Metadata.get_call_location(), time.time()))
+
         imported_code_ids = [td["gender_coded"]["CodeID"] for td in imported_messages]
 
         self.assertListEqual(imported_code_ids, [nr_id, na_id, nr_id, na_id, nr_id, nr_id])
@@ -124,6 +125,19 @@ class TestTracedDataCodaV2IO(unittest.TestCase):
         with open("tests/traced_data/resources/coda_2_import_test_one_scheme.json", "r") as f:
             TracedDataCodaV2IO.import_coda_2_to_traced_data_iterable(
                 "test_user", imported_messages, "gender_coda_id", {"gender_coded": gender_scheme}, f)
+
+        # Set TRUE_MISSING codes
+        for td in imported_messages:
+            na_label = CleaningUtils.make_label_from_cleaner_code(
+                gender_scheme,
+                gender_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
+                "test_export_traced_data_iterable_to_coda_2",
+                date_time_utc="2018-11-02T10:00:00+00:00"
+            )
+            if td.get("gender_raw", "") == "":
+                td.append_data({"gender_coded": na_label.to_dict()},
+                               Metadata("test_user", Metadata.get_call_location(), time.time()))
+
         imported_code_ids = [td["gender_coded"]["CodeID"] for td in imported_messages]
 
         expected_code_ids = [
@@ -222,38 +236,6 @@ class TestTracedDataCodaV2IO(unittest.TestCase):
         self.assertTrue(
             filecmp.cmp(file_path, "tests/traced_data/resources/coda_2_export_expected_multiple_schemes.json"))
 
-        # Test ambiguous missing codes
-        def test_ambiguous_missing_codes(d):
-            # Test exporting with ambiguous missing codes
-            conflicting_missings = list(messages)
-            conflicting_missings.append(TracedData(d, Metadata("test_user", Metadata.get_call_location(), time.time())))
-            TracedDataCodaV2IO.compute_message_ids("test_user", conflicting_missings, "location_raw", "location_coda_id")
-
-            with open(file_path, "w") as f:
-                try:
-                    scheme_key_map = collections.OrderedDict()
-                    scheme_key_map["district"] = district_scheme
-                    scheme_key_map["zone"] = zone_scheme
-
-                    TracedDataCodaV2IO.export_traced_data_iterable_to_coda_2(
-                        conflicting_missings, "location_raw", "location_sent_on", "location_coda_id", scheme_key_map, f)
-                except AssertionError as e:
-                    assert str(e) == "Data labelled as NA or NS under one code scheme but not all of the others"
-                    return
-                self.fail("Exporting data with ambiguous missing codes did not fail")
-
-        test_ambiguous_missing_codes({
-            "location_raw": "baidoa", "location_sent_on": "2018-11-01T07:19:30+03:00",
-            "district": make_location_label(district_scheme, Codes.TRUE_MISSING),
-            "zone": make_location_label(zone_scheme, Codes.NOT_CODED)
-        })
-
-        test_ambiguous_missing_codes({
-            "location_raw": "baidoa", "location_sent_on": "2018-11-01T07:19:30+03:00",
-            "district": make_location_label(district_scheme, Codes.TRUE_MISSING),
-            "zone": make_location_label(zone_scheme, Codes.SKIPPED)
-        })
-
     def test_export_import_one_multi_coded_scheme(self):
         file_path = path.join(self.test_dir, "coda_2_test.json")
 
@@ -276,18 +258,6 @@ class TestTracedDataCodaV2IO(unittest.TestCase):
         with open("tests/traced_data/resources/coda_2_msg_scheme.json") as f:
             msg_scheme = Scheme.from_firebase_map(json.load(f))
 
-        # Set TRUE_MISSING codes
-        for td in messages:
-            na_label = CleaningUtils.make_label_from_cleaner_code(
-                msg_scheme,
-                msg_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
-                "test_export_traced_data_iterable_to_coda_2",
-                date_time_utc="2018-11-02T10:00:00+00:00"
-            )
-            if td.get("msg_raw", "") == "":
-                td.append_data({"msg_coded": [na_label.to_dict()]},
-                               Metadata("test_user", Metadata.get_call_location(), time.time()))
-
         # Export to a Coda 2 messages file
         with open(file_path, "w") as f:
             TracedDataCodaV2IO.export_traced_data_iterable_to_coda_2(
@@ -308,6 +278,18 @@ class TestTracedDataCodaV2IO(unittest.TestCase):
         na_id = msg_scheme.get_code_with_control_code(Codes.TRUE_MISSING).code_id
         nr_id = msg_scheme.get_code_with_control_code(Codes.NOT_REVIEWED).code_id
 
+        # Set TRUE_MISSING codes
+        for td in imported_messages:
+            na_label = CleaningUtils.make_label_from_cleaner_code(
+                msg_scheme,
+                msg_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
+                "test_export_traced_data_iterable_to_coda_2",
+                date_time_utc="2018-11-02T10:00:00+00:00"
+            )
+            if td.get("msg_raw", "") == "":
+                td.append_data({"msg_coded": [na_label.to_dict()]},
+                               Metadata("test_user", Metadata.get_call_location(), time.time()))
+
         for td in imported_messages:
             self.assertEqual(len(td["msg_coded"]), 1)
         imported_code_ids = [td["msg_coded"][0]["CodeID"] for td in imported_messages]
@@ -320,6 +302,18 @@ class TestTracedDataCodaV2IO(unittest.TestCase):
         with open("tests/traced_data/resources/coda_2_import_test_multi_coded.json", "r") as f:
             TracedDataCodaV2IO.import_coda_2_to_traced_data_iterable_multi_coded(
                 "test_user", imported_messages, "msg_coda_id", {"msg_coded": msg_scheme}, f)
+
+        # Set TRUE_MISSING codes
+        for td in imported_messages:
+            na_label = CleaningUtils.make_label_from_cleaner_code(
+                msg_scheme,
+                msg_scheme.get_code_with_control_code(Codes.TRUE_MISSING),
+                "test_export_traced_data_iterable_to_coda_2",
+                date_time_utc="2018-11-02T10:00:00+00:00"
+            )
+            if td.get("msg_raw", "") == "":
+                td.append_data({"msg_coded": [na_label.to_dict()]},
+                               Metadata("test_user", Metadata.get_call_location(), time.time()))
 
         imported_code_ids = []
         for td in imported_messages:


### PR DESCRIPTION
This removes some of the "magic" which TracedDataCodaV2IO is currently performing. Pipelines will need to adapt to these changes by moving the NA/NS assignment to happen after all of the Coda IO rather than before, which has the nice side effect of reducing the amount of pre-processing that takes place between data fetch and export to coda.

For an example of how this impacts a pipeline, see https://github.com/AfricasVoices/Project-ADSS/pull/24