### PR TITLE
Add header doc describing where to find the data_format spec for Schemes

### DIFF
--- a/core_data_modules/data_models/scheme.py
+++ b/core_data_modules/data_models/scheme.py
@@ -1,6 +1,18 @@
 from core_data_modules.data_models import validators
 
 
+"""
+This module contains Python representations of the objects needed to construct entries in a Coda V2 code scheme file,
+and contains functions for validating, serializing, and de-serializing.
+
+The data formats are specified here:
+https://github.com/AfricasVoices/CodaV2/blob/master/docs/data_formats.md#code-schemes
+
+Changes to this file will need to be synced with changes to that specification, and with all other uses of that
+specification.
+"""
+
+
 class Scheme(object):
     def __init__(self, scheme_id, name, version, codes, documentation=None):
         self.scheme_id = scheme_id


### PR DESCRIPTION
This uses the same language as the one which already exists in this repo at the top of messages.py, but with references to messages updated to refer to code schemes.