### PR TITLE
Fully support meta codes

### DIFF
--- a/core_data_modules/cleaners/codes/codes.py
+++ b/core_data_modules/cleaners/codes/codes.py
@@ -34,3 +34,4 @@ class Codes(object):
     SHOWTIME_QUESTION = "showtime_question"
     QUESTION = "question"
     GREETING = "greeting"
+    OPT_IN = "opt_in"

--- a/core_data_modules/cleaners/codes/codes.py
+++ b/core_data_modules/cleaners/codes/codes.py
@@ -1,7 +1,5 @@
 class Codes(object):
-    TRUE = "true"
-    FALSE = "false"
-
+    # Demographic codes
     MALE = "male"
     FEMALE = "female"
 
@@ -12,11 +10,15 @@ class Codes(object):
     URBAN = "urban"
     RURAL = "rural"
 
+    # Pipeline support codes
+    TRUE = "true"
+    FALSE = "false"
+
     MATRIX_0 = "0"
     MATRIX_1 = "1"
 
+    # Control Codes
     STOP = "STOP"
-
     TRUE_MISSING = "NA"
     SKIPPED = "NS"
     NOT_INTERNALLY_CONSISTENT = "NIC"
@@ -26,3 +28,9 @@ class Codes(object):
     WRONG_SCHEME = "WS"
     NOISE_OTHER_PROJECT = "NOP"  # Deprecated; use NOISE_OTHER_CHANNEL instead.
     NOISE_OTHER_CHANNEL = "NOC"
+
+    # Meta Codes
+    PUSH_BACK = "push_back"
+    SHOWTIME_QUESTION = "showtime_question"
+    QUESTION = "question"
+    GREETING = "greeting"

--- a/core_data_modules/data_models/scheme.py
+++ b/core_data_modules/data_models/scheme.py
@@ -133,6 +133,7 @@ class Code:
         display_text = data["DisplayText"]
         code_type = data["CodeType"]
         control_code = data.get("ControlCode")
+        meta_code = data.get("MetaCode")
         shortcut = data.get("Shortcut")
         numeric_value = data["NumericValue"]
         string_value = data["StringValue"]
@@ -141,7 +142,7 @@ class Code:
         match_values = data.get("MatchValues")
 
         return cls(code_id, code_type, display_text, numeric_value, string_value, visible_in_coda, shortcut,
-                   color, match_values, control_code)
+                   color, match_values, control_code, meta_code)
 
     def to_firebase_map(self):
         self.validate()
@@ -157,6 +158,9 @@ class Code:
 
         if self.control_code is not None:
             ret["ControlCode"] = self.control_code
+
+        if self.meta_code is not None:
+            ret["MetaCode"] = self.meta_code
 
         if self.shortcut is not None:
             ret["Shortcut"] = self.shortcut

--- a/core_data_modules/data_models/scheme.py
+++ b/core_data_modules/data_models/scheme.py
@@ -19,9 +19,15 @@ class Scheme(object):
 
     def get_code_with_control_code(self, control_code):
         for code in self.codes:
-            if code.control_code == control_code:
+            if code.code_type == CodeTypes.CONTROL and code.control_code == control_code:
                 return code
         raise KeyError("Scheme '{}' (id '{}') does not contain a code with control code '{}'".format(self.name, self.scheme_id, control_code))
+
+    def get_code_with_meta_code(self, meta_code):
+        for code in self.codes:
+            if code.code_type == CodeTypes.META and code.meta_code == meta_code:
+                return code
+        raise KeyError("Scheme '{}' (id '{}') does not contain a code with meta code '{}'".format(self.name, self.scheme_id, meta_code))
 
     def get_code_with_match_value(self, match_value):
         for code in self.codes:
@@ -96,14 +102,21 @@ class Scheme(object):
         return not self.__eq__(other)
 
 
+class CodeTypes:
+    NORMAL = "Normal"
+    CONTROL = "Control"
+    META = "Meta"
+
+
 class Code:
-    VALID_CODE_TYPES = {"Normal", "Control", "Meta"}
+    VALID_CODE_TYPES = {CodeTypes.NORMAL, CodeTypes.CONTROL, CodeTypes.META}
 
     def __init__(self, code_id, code_type, display_text, numeric_value, string_value, visible_in_coda, shortcut=None,
-                 color=None, match_values=None, control_code=None):
+                 color=None, match_values=None, control_code=None, meta_code=None):
         self.code_id = code_id
         self.code_type = code_type
         self.control_code = control_code
+        self.meta_code = meta_code
         self.display_text = display_text
         self.shortcut = shortcut
         self.numeric_value = numeric_value
@@ -162,8 +175,10 @@ class Code:
 
         validators.validate_string(self.code_type, "code_type")
         assert self.code_type in self.VALID_CODE_TYPES, f"CodeType '{self.code_type}' invalid"
-        if self.code_type == "Control":
+        if self.code_type == CodeTypes.CONTROL:
             validators.validate_string(self.control_code, "control_code")
+        if self.code_type == CodeTypes.META:
+            validators.validate_string(self.meta_code, "meta_code")
 
         if self.shortcut is not None:
             validators.validate_string(self.shortcut, "shortcut")
@@ -187,6 +202,7 @@ class Code:
         return other.code_id == self.code_id and \
             other.code_type == self.code_type and \
             other.control_code == self.control_code and \
+            other.meta_code == self.meta_code and \
             other.display_text == self.display_text and \
             other.shortcut == self.shortcut and \
             other.numeric_value == self.numeric_value and \


### PR DESCRIPTION
Adds:
 - Scheme.get_code_with_meta_code for looking up the Code object associated with a particular meta code in a scheme.
 - The current standard meta codes to codes.py