### PR TITLE
Remove Codes.NOISE_OTHER_PROJECT

### DIFF
--- a/core_data_modules/cleaners/codes/codes.py
+++ b/core_data_modules/cleaners/codes/codes.py
@@ -24,5 +24,4 @@ class Codes(object):
     NOT_REVIEWED = "NR"
     NOT_CODED = "NC"
     WRONG_SCHEME = "WS"
-    NOISE_OTHER_PROJECT = "NOP"  # Deprecated; use NOISE_OTHER_CHANNEL instead.
     NOISE_OTHER_CHANNEL = "NOC"

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -76,8 +76,7 @@ class FoldTracedData(object):
     def _is_control_code(code):
         return code in {
             Codes.STOP, Codes.CODING_ERROR, Codes.NOT_REVIEWED, Codes.NOT_INTERNALLY_CONSISTENT,
-            Codes.NOT_CODED, Codes.TRUE_MISSING, Codes.SKIPPED, Codes.WRONG_SCHEME, Codes.NOISE_OTHER_PROJECT,
-            Codes.NOISE_OTHER_CHANNEL, None
+            Codes.NOT_CODED, Codes.TRUE_MISSING, Codes.SKIPPED, Codes.WRONG_SCHEME, Codes.NOISE_OTHER_CHANNEL, None
         }
 
     @staticmethod
@@ -94,7 +93,6 @@ class FoldTracedData(object):
          - Codes.TRUE_MISSING
          - Codes.SKIPPED
          - Codes.WRONG_SCHEME
-         - Codes.NOISE_OTHER_PROJECT
          - None
 
         :param value_1: Code to reconcile.
@@ -107,8 +105,7 @@ class FoldTracedData(object):
         # Precedence order in case of conflicts; highest precedence first
         precedence_order = [
             Codes.STOP, Codes.CODING_ERROR, Codes.NOT_REVIEWED, Codes.NOT_INTERNALLY_CONSISTENT,
-            Codes.NOT_CODED, Codes.TRUE_MISSING, Codes.SKIPPED, Codes.WRONG_SCHEME, Codes.NOISE_OTHER_PROJECT,
-            Codes.NOISE_OTHER_CHANNEL, None
+            Codes.NOT_CODED, Codes.TRUE_MISSING, Codes.SKIPPED, Codes.WRONG_SCHEME, Codes.NOISE_OTHER_CHANNEL, None
         ]
 
         assert value_1 in precedence_order, "value_1 ('{}') not a missing or stop code".format(value_1)

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -93,6 +93,7 @@ class FoldTracedData(object):
          - Codes.TRUE_MISSING
          - Codes.SKIPPED
          - Codes.WRONG_SCHEME
+         - Codes.NOISE_OTHER_CHANNEL
          - None
 
         :param value_1: Code to reconcile.


### PR DESCRIPTION
This was added to support ICRAF, but then deprecated in favour of NOISE_OTHER_CHANNEL.

Given that ICRAF ended a while ago and we have other breaking changes that will be released into Core soon, now feels like a good time to remove it.