### PR TITLE
Update the fold functions to take fold strategies instead of *_keys arguments

### DIFF
--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -9,7 +9,7 @@ class FoldStrategies(object):
     
     All reconciliation functions take two values, apply some logic to produce the
     """
-    AMBIVALENT_BINARY_VALUE = "ambivalent"
+    AMBIVALENT_BINARY_VALUE = "ambivalent"  # TODO: Move to Core
 
     @staticmethod
     def assert_equal(x, y):
@@ -124,7 +124,7 @@ class FoldTracedData(object):
         :param fold_fn: Function to use to fold each pair of TracedData objects.
         :type fold_fn: function of (TracedData, TracedData) -> TracedData
         :return: Folded TracedData objects.
-        :rtype: iterable of TracedData
+        :rtype: list of TracedData
         """
         folded_data = []
 
@@ -137,7 +137,24 @@ class FoldTracedData(object):
         return folded_data
 
     @staticmethod
-    def fold_traced_data(user, td_1, td_2, fold_strategies):  # r_strategies: dict of (key -> strategy func)
+    def fold_traced_data(user, td_1, td_2, fold_strategies):
+        """
+        Folds two TracedData objects into a new TracedData object.
+
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param td_1: First TracedData object to fold.
+        :type td_1: TracedData
+        :param td_2: Second TracedData object to fold.
+        :type td_2: TracedData
+        :param fold_strategies: Dictionary of TracedData key to the folding strategy to apply to that key.
+                                A folding strategy is a function which folds two individual values.
+                                Standard folding functions are available at
+                                `core_data_modules.traced_data.util.FoldStrategies`.
+        :type fold_strategies: dict of str -> (function of (any, any) -> any)
+        :return: td_1 folded with td_2.
+        :rtype: TracedData
+        """
         # Create (shallow) copies of the input TracedData so that we can fold without modifying the arguments.
         # TODO: Is this necessary?
         td_1 = td_1.copy()
@@ -169,6 +186,26 @@ class FoldTracedData(object):
 
     @classmethod
     def fold_iterable_of_traced_data(cls, user, data, fold_id_fn, fold_strategies):
+        """
+        Folds an iterable of TracedData into a new iterable of TracedData.
+        
+        Objects with the same fold id (as determined by 'fold_id_fn') are folded together into a new TracedData object.
+        
+        :param user: Identifier of the user running this program, for TracedData Metadata.
+        :type user: str
+        :param data: TracedData objects to fold.
+        :type data: iterable of TracedData
+        :param fold_id_fn: Function which generates a fold id for a TracedData object.
+                           TracedData objects with the same fold id will be folded into a single, new TracedData object.
+        :type fold_id_fn: function of TracedData -> hashable
+        :param fold_strategies: Dictionary of TracedData key to the folding strategy to apply to that key.
+                                A folding strategy is a function which folds two individual values.
+                                Standard folding functions are available at
+                                `core_data_modules.traced_data.util.FoldStrategies`.
+        :type fold_strategies: dict of str -> (function of (any, any) -> any)
+        :return: Folded TracedData objects.
+        :rtype: list of TracedData
+        """
         return cls.fold_groups(
             cls.group_by(data, fold_id_fn),
             lambda td_1, td_2: cls.fold_traced_data(user, td_1, td_2, fold_strategies)

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -1,5 +1,3 @@
-import time
-
 from core_data_modules.cleaners import Codes
 from core_data_modules.traced_data import Metadata
 from core_data_modules.util import TimeUtils
@@ -182,22 +180,6 @@ class FoldTracedData(object):
             return value_1
         else:
             return value_2
-
-    @staticmethod
-    def set_keys_to_value(user, td, keys, value="MERGED"):
-        """
-        Sets the given keys in a TracedData object to the same given value.
-
-        :param user: Identifier of the user running this program, for TracedData Metadata.
-        :type user: str
-        :param td: TracedData object to set the keys of.
-        :type td: TracedData
-        :param keys: Keys to set.
-        :type keys: iterable of str
-        :param value: Value to set each key to.
-        :type value: str
-        """
-        td.append_data({key: value for key in keys}, Metadata(user, Metadata.get_call_location(), time.time()))
 
     @staticmethod
     def fold_traced_data(user, td_1, td_2, fold_strategies):  # r_strategies: dict of (key -> strategy func)

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -184,56 +184,6 @@ class FoldTracedData(object):
             return value_2
 
     @staticmethod
-    def reconcile_matrix_keys(user, td_1, td_2, keys):
-        """
-        Sets given keys in two TracedData objects to the same value, of Codes.MATRIX_1 if the value in either
-        of those objects is Codes.MATRIX_1, otherwise sets the values to Codes.MATRIX_0.
-
-        An exception is made for keys ending with Codes.NOT_CODED - in this case, the folded value is Codes.MATRIX_0
-        unless the value in both td_1 and td_2 is Codes.MATRIX_1.
-
-        :param user: Identifier of the user running this program, for TracedData Metadata.
-        :type user: str
-        :param td_1: TracedData object to reconcile the matrix keys of.
-        :type td_1: TracedData
-        :param td_2: TracedData object to reconcile the matrix keys of.
-        :type td_2: TracedData
-        :param keys: Keys in each TracedData object to reconcile.
-        :type keys: iterable of str
-        """
-        matrix_dict = dict()
-
-        possible_matrix_values = {Codes.MATRIX_0, Codes.MATRIX_1}
-        for key in keys:
-            if td_1.get(key) == Codes.STOP or td_2.get(key) == Codes.STOP:
-                matrix_dict[key] = Codes.STOP
-                continue
-
-            # TODO: Handle the different modes of missing data
-
-            if key.endswith(Codes.NOT_CODED):
-                if td_1.get(key) == Codes.MATRIX_0 or td_2.get(key) == Codes.MATRIX_0:
-                    matrix_dict[key] = Codes.MATRIX_0
-                else:
-                    matrix_dict[key] = Codes.MATRIX_1
-                continue
-
-            assert td_1.get(key) in possible_matrix_values, \
-                "td_1.get('{}') is not '{}' or '{}' (has value '{}')".format(
-                    key, Codes.MATRIX_0, Codes.MATRIX_1, td_1.get(key))
-            assert td_2.get(key) in possible_matrix_values, \
-                "td_2.get('{}') is not '{}' or '{}' (has value '{}')".format(
-                    key, Codes.MATRIX_0, Codes.MATRIX_1, td_2.get(key))
-
-            if td_1.get(key) == Codes.MATRIX_1 or td_2.get(key) == Codes.MATRIX_1:
-                matrix_dict[key] = Codes.MATRIX_1
-            else:
-                matrix_dict[key] = Codes.MATRIX_0
-
-        td_1.append_data(matrix_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-        td_2.append_data(matrix_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-
-    @staticmethod
     def reconcile_boolean_keys(user, td_1, td_2, keys):
         """
         Sets the given keys in two TracedData objects to the same value, of Codes.TRUE if the value in either

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -96,8 +96,8 @@ class FoldStrategies(object):
             Codes.NOT_CODED, Codes.TRUE_MISSING, Codes.SKIPPED, Codes.WRONG_SCHEME, Codes.NOISE_OTHER_CHANNEL, None
         ]
 
-        assert x in precedence_order, "value_1 ('{}') not a missing or stop code".format(x)
-        assert y in precedence_order, "value_2 ('{}') not a missing or stop code".format(y)
+        assert x in precedence_order, "value_1 ('{}') not a control code".format(x)
+        assert y in precedence_order, "value_2 ('{}') not a control code".format(y)
 
         if precedence_order.index(x) <= precedence_order.index(y):
             return x

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -67,7 +67,7 @@ class FoldStrategies(object):
         return code in cls.CONTROL_CODES
 
     @staticmethod
-    def control_code(x, y):
+    def control_code_by_precedence(x, y):
         """
         Folds two control codes, by choosing the control code with the highest precedence.
 
@@ -165,7 +165,7 @@ class FoldStrategies(object):
         assert y in {Codes.YES, Codes.NO, cls.AMBIVALENT_BINARY_VALUE} or y in cls.CONTROL_CODES
 
         if cls._is_control_code(x) and cls._is_control_code(y):
-            return cls.control_code(x, y)
+            return cls.control_code_by_precedence(x, y)
         elif cls._is_control_code(x):
             return y
         elif cls._is_control_code(y):

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -183,34 +183,6 @@ class FoldTracedData(object):
         else:
             return value_2
 
-    @staticmethod
-    def reconcile_boolean_keys(user, td_1, td_2, keys):
-        """
-        Sets the given keys in two TracedData objects to the same value, of Codes.TRUE if the value in either
-        of those objects is Codes.TRUE, otherwise sets the values to Codes.FALSE.
-
-        :param user: Identifier of the user running this program, for TracedData Metadata.
-        :type user: str
-        :param td_1: TracedData object to reconcile the boolean keys of.
-        :type td_1: TracedData
-        :param td_2: TracedData object to reconcile the boolean keys of.
-        :type td_2: TracedData
-        :param keys: Keys in each TracedData object to reconcile.
-        :type keys: iterable of str
-        """
-        bool_dict = dict()
-
-        for key in keys:
-            if td_1.get(key) == Codes.TRUE or td_2.get(key) == Codes.TRUE:
-                bool_dict[key] = Codes.TRUE
-            else:
-                bool_dict[key] = Codes.FALSE
-
-        td_1.append_data(bool_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-        td_2.append_data(bool_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-
-    # TODO: Support reconciling datetime strings
-
     @classmethod
     def reconcile_yes_no_keys(cls, user, td_1, td_2, keys):
         """

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -183,48 +183,6 @@ class FoldTracedData(object):
         else:
             return value_2
 
-    @classmethod
-    def reconcile_yes_no_keys(cls, user, td_1, td_2, keys):
-        """
-        Sets the given keys in two TracedData objects to the same yes/no/both value, using the logic given below.
-
-        The value set for each key is:
-         - Codes.STOP if either value is Codes.STOP
-         - Codes.BOTH if either value is Codes.BOTH
-         - Codes.BOTH if one value is Codes.YES and the other value is Codes.NO
-         - Codes.YES if both values are Codes.YES
-         - Codes.NO if both values are Codes.NO
-         - value 1 if value 1 is Codes.YES or Codes.NO, and value 2 is neither Codes.YES nor Codes.NO
-         - value 2 if value 2 is Codes.YES or Codes.NO, and value 1 is neither Codes.YES nor Codes.NO
-        If none of the above conditions are true, the logic of FoldTracedData.reconcile_missing_values is applied.
-
-        :param user: Identifier of the user running this program, for TracedData Metadata.
-        :type user: str
-        :param td_1: TracedData object to reconcile the yes/no keys of.
-        :type td_1: TracedData
-        :param td_2: TracedData object to reconcile the yes/no keys of.
-        :type td_2: TracedData
-        :param keys: Keys in each TracedData object to reconcile.
-        :type keys: iterable of str
-        """
-        yes_no_dict = dict()
-
-        for key in keys:
-            if td_1.get(key) == Codes.STOP or td_2.get(key) == Codes.STOP:
-                yes_no_dict[key] = Codes.STOP
-            elif td_1.get(key) == Codes.BOTH or td_2.get(key) == Codes.BOTH:
-                yes_no_dict[key] = Codes.BOTH
-            elif td_1.get(key) in {Codes.YES, Codes.NO} and td_2.get(key) in {Codes.YES, Codes.NO}:
-                yes_no_dict[key] = td_1[key] if td_1[key] == td_2[key] else Codes.BOTH
-            elif td_1.get(key) in {Codes.YES, Codes.NO}:
-                yes_no_dict[key] = td_1[key]
-            elif td_2.get(key) in {Codes.YES, Codes.NO}:
-                yes_no_dict[key] = td_2[key]
-            else:
-                yes_no_dict[key] = cls.reconcile_missing_values(td_1.get(key), td_2.get(key))
-
-        td_1.append_data(yes_no_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-        td_2.append_data(yes_no_dict, Metadata(user, Metadata.get_call_location(), time.time()))
 
     @classmethod
     def reconcile_binary_keys(cls, user, td_1, td_2, keys):

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -137,51 +137,6 @@ class FoldTracedData(object):
         return folded_data
 
     @staticmethod
-    def _is_control_code(code):
-        return code in {
-            Codes.STOP, Codes.CODING_ERROR, Codes.NOT_REVIEWED, Codes.NOT_INTERNALLY_CONSISTENT,
-            Codes.NOT_CODED, Codes.TRUE_MISSING, Codes.SKIPPED, Codes.WRONG_SCHEME, Codes.NOISE_OTHER_CHANNEL, None
-        }
-
-    @staticmethod
-    def reconcile_missing_values(value_1, value_2):
-        """
-        Reconciles two missing values, by choosing the form of missing value with the highest precedence.
-
-        The precedence order for missing values is defined as follows (highest precedence listed first):
-         - Codes.STOP
-         - Codes.CODING_ERROR
-         - Codes.NOT_REVIEWED
-         - Codes.NOT_INTERNALLY_CONSISTENT
-         - Codes.NOT_CODED
-         - Codes.TRUE_MISSING
-         - Codes.SKIPPED
-         - Codes.WRONG_SCHEME
-         - Codes.NOISE_OTHER_CHANNEL
-         - None
-
-        :param value_1: Code to reconcile.
-        :type value_1: str
-        :param value_2: Code to reconcile.
-        :type value_2: str
-        :return: Reconciled code.
-        :rtype: str
-        """
-        # Precedence order in case of conflicts; highest precedence first
-        precedence_order = [
-            Codes.STOP, Codes.CODING_ERROR, Codes.NOT_REVIEWED, Codes.NOT_INTERNALLY_CONSISTENT,
-            Codes.NOT_CODED, Codes.TRUE_MISSING, Codes.SKIPPED, Codes.WRONG_SCHEME, Codes.NOISE_OTHER_CHANNEL, None
-        ]
-
-        assert value_1 in precedence_order, "value_1 ('{}') not a missing or stop code".format(value_1)
-        assert value_2 in precedence_order, "value_2 ('{}') not a missing or stop code".format(value_2)
-
-        if precedence_order.index(value_1) <= precedence_order.index(value_2):
-            return value_1
-        else:
-            return value_2
-
-    @staticmethod
     def fold_traced_data(user, td_1, td_2, fold_strategies):  # r_strategies: dict of (key -> strategy func)
         # Create (shallow) copies of the input TracedData so that we can fold without modifying the arguments.
         # TODO: Is this necessary?

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -20,6 +20,11 @@ class FoldStrategies(object):
 
     @staticmethod
     def concatenate(x, y):
+        if x is None:
+            return y
+        if y is None:
+            return x
+
         return f"{x};{y}"
 
     @staticmethod
@@ -412,7 +417,9 @@ class FoldTracedData(object):
         # Fold the specified keys using the provided fold strategies.
         folded_dict = dict()
         for key, strategy in fold_strategies.items():
-            folded_dict[key] = strategy(td_1[key], td_2[key])
+            folded_value = strategy(td_1.get(key), td_2.get(key))
+            if folded_value is not None:
+                folded_dict[key] = folded_value
         td_1.append_data(folded_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
         td_2.append_data(folded_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -63,8 +63,8 @@ class FoldStrategies(object):
     @staticmethod
     def matrix(x, y):
         # TODO: Do the pipelines still need this check?
-        if x == Codes.STOP or y == Codes.STOP:
-            return Codes.STOP
+        # if x == Codes.STOP or y == Codes.STOP:
+        #     return Codes.STOP
         
         if x == Codes.MATRIX_1 or y == Codes.MATRIX_1:
             return Codes.MATRIX_1

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -62,6 +62,9 @@ class FoldStrategies(object):
         
     @staticmethod
     def matrix(x, y):
+        assert x in {Codes.MATRIX_0, Codes.MATRIX_1}
+        assert y in {Codes.MATRIX_0, Codes.MATRIX_1}
+
         if x == Codes.MATRIX_1 or y == Codes.MATRIX_1:
             return Codes.MATRIX_1
         else:

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -137,25 +137,6 @@ class FoldTracedData(object):
         return folded_data
 
     @staticmethod
-    def assert_equal_keys_equal(td_1, td_2, equal_keys):
-        """
-        Checks that the provided TracedData objects contain exactly the same values for each of the provided keys.
-
-        Raises an AssertionError if mis-matching keys are found, otherwise returns no value and has no side-effect.
-
-        :param td_1: TracedData object to check for value equality.
-        :type td_1: TracedData
-        :param td_2: TracedData object to check for value equality.
-        :type td_2: TracedData
-        :param equal_keys: Keys to check for equality in the TracedData objects.
-        :type equal_keys: iterable of str
-        """
-        for key in equal_keys:
-            assert td_1.get(key) == td_2.get(key), "Key '{}' should be the same in both td_1 and td_2 but is " \
-                                                   "different (has values '{}' and '{}' " \
-                                                   "respectively)".format(key, td_1.get(key), td_2.get(key))
-
-    @staticmethod
     def _is_control_code(code):
         return code in {
             Codes.STOP, Codes.CODING_ERROR, Codes.NOT_REVIEWED, Codes.NOT_INTERNALLY_CONSISTENT,
@@ -431,7 +412,7 @@ class FoldTracedData(object):
         td_2.hide_keys(set(td_2.keys()) - set(folded_dict.keys()),
                        Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
 
-        # Append one traced data to the other (to ensure we have a record of both histories), and return
+        # Append one traced data to the other (to ensure we have a record of both histories), and return.
         folded_td = td_1
         folded_td.append_traced_data("folded_with", td_2,
                                      Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -179,8 +179,6 @@ class FoldStrategies(object):
         
 
 class FoldTracedData(object):
-    AMBIVALENT_BINARY_VALUE = "ambivalent"
-
     @staticmethod
     def group_by(data, group_id_fn):
         """

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -62,10 +62,6 @@ class FoldStrategies(object):
         
     @staticmethod
     def matrix(x, y):
-        # TODO: Do the pipelines still need this check?
-        # if x == Codes.STOP or y == Codes.STOP:
-        #     return Codes.STOP
-        
         if x == Codes.MATRIX_1 or y == Codes.MATRIX_1:
             return Codes.MATRIX_1
         else:

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -182,35 +182,6 @@ class FoldTracedData(object):
             return value_2
 
     @staticmethod
-    def reconcile_keys_by_concatenation(user, td_1, td_2, keys, concat_delimiter=";"):
-        """
-        Sets the given keys in two TracedData objects to the same value by string concatenating the values of each.
-
-        Concatenated values take the form <td_1[key]><concat_delimiter><td_2[key]>.
-
-        :param user: Identifier of the user running this program, for TracedData Metadata.
-        :type user: str
-        :param td_1: First TracedData object to concatenate the keys with.
-                     This value will appear first in the concatenated string i.e. before the concat_delimiter.
-        :type td_1: TracedData
-        :param td_2: Second TracedData object to concatenate the keys with.
-                     This value will appear first in the concatenated string i.e. after the concat_delimiter.
-        :type td_2: TracedData
-        :param keys: Keys in each TracedData object to concatenate the values of.
-        :type keys: iterable of str
-        :param concat_delimiter: String to separate the concatenated strings with.
-        :type concat_delimiter: str
-        """
-        concat_dict = dict()
-
-        for key in keys:
-            if key in td_1 and key in td_2:
-                concat_dict[key] = "{}{}{}".format(td_1[key], concat_delimiter, td_2[key])
-
-        td_1.append_data(concat_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-        td_2.append_data(concat_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-
-    @staticmethod
     def reconcile_matrix_keys(user, td_1, td_2, keys):
         """
         Sets given keys in two TracedData objects to the same value, of Codes.MATRIX_1 if the value in either

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -29,6 +29,8 @@ class FoldStrategies(object):
 
     @staticmethod
     def _is_control_code(code):
+        # TODO: If we move this function to `Codes`, that will reduce the risk of us updating Core but not updating
+        #       the body of this function.
         return code in {
             Codes.STOP, Codes.CODING_ERROR, Codes.NOT_REVIEWED, Codes.NOT_INTERNALLY_CONSISTENT,
             Codes.NOT_CODED, Codes.TRUE_MISSING, Codes.SKIPPED, Codes.WRONG_SCHEME, Codes.NOISE_OTHER_CHANNEL, None

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -183,48 +183,6 @@ class FoldTracedData(object):
         else:
             return value_2
 
-
-    @classmethod
-    def reconcile_binary_keys(cls, user, td_1, td_2, keys):
-        """
-        Sets the given keys in two TracedData objects to the same value, using the logic given below.
-
-        The value set for each key is:
-         - The result of cls.reconcile_missing_values if both value 1 and value 2 are missing.
-         - value 1 if value 2 is a control code and value 1 is not.
-         - value 2 if value 1 is a control code and value 2 is not.
-         - cls.AMBIVALENT_BINARY_VALUE if value 1 and value 2 are both cls.AMBIVALENT_BINARY_VALUE.
-         - the common value if value 1 == value 2.
-         - cls.AMBIVALENT_BINARY_VALUE if value 1 and and value 2 differ.
-
-        :param user: Identifier of the user running this program, for TracedData Metadata.
-        :type user: str
-        :param td_1: TracedData object to reconcile the binary keys of.
-        :type td_1: TracedData
-        :param td_2: TracedData object to reconcile the binary keys of.
-        :type td_2: TracedData
-        :param keys: Keys in each TracedData object to reconcile.
-        :type keys: iterable of str
-        """
-        binary_dict = dict()
-
-        for key in keys:
-            if cls._is_control_code(td_1.get(key)) and cls._is_control_code(td_2.get(key)):
-                binary_dict[key] = cls.reconcile_missing_values(td_1.get(key), td_2.get(key))
-            elif cls._is_control_code(td_1.get(key)):
-                binary_dict[key] = td_2.get(key)
-            elif cls._is_control_code(td_2.get(key)):
-                binary_dict[key] = td_1.get(key)
-            elif td_1.get(key) == cls.AMBIVALENT_BINARY_VALUE or td_1.get(key) == cls.AMBIVALENT_BINARY_VALUE:
-                binary_dict[key] = cls.AMBIVALENT_BINARY_VALUE
-            elif td_1.get(key) == td_2.get(key):
-                binary_dict[key] = td_1.get(key)
-            else:
-                binary_dict[key] = cls.AMBIVALENT_BINARY_VALUE
-
-        td_1.append_data(binary_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-        td_2.append_data(binary_dict, Metadata(user, Metadata.get_call_location(), time.time()))
-
     @staticmethod
     def set_keys_to_value(user, td, keys, value="MERGED"):
         """

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -29,6 +29,11 @@ class TestReconciliationFunctions(unittest.TestCase):
         self.assertEqual(FoldStrategies.concatenate("", "def"), ";def")
         self.assertEqual(FoldStrategies.concatenate(None, "def"), "def")
         self.assertEqual(FoldStrategies.concatenate(None, None), None)
+        
+    def test_boolean_or(self):
+        self.assertEqual(FoldStrategies.boolean_or(Codes.TRUE, Codes.TRUE), Codes.TRUE)
+        self.assertEqual(FoldStrategies.boolean_or(Codes.FALSE, Codes.TRUE), Codes.TRUE)
+        self.assertEqual(FoldStrategies.boolean_or(Codes.FALSE, Codes.FALSE), Codes.FALSE)
 
     def test_matrix(self):
         self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_1, Codes.MATRIX_1), Codes.MATRIX_1)

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -107,23 +107,6 @@ class TestFoldTracedData(unittest.TestCase):
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
-    def test_reconcile_boolean_keys(self):
-        td_1 = TracedData(
-            {"a": Codes.TRUE, "b": Codes.FALSE, "c": Codes.FALSE, "d": Codes.NOT_CODED, "e": Codes.NOT_CODED},
-            Metadata("test_user", Metadata.get_call_location(), 0)
-        )
-
-        td_2 = TracedData(
-            {"a": Codes.TRUE, "b": Codes.TRUE, "c": Codes.FALSE, "d": Codes.TRUE, "e": Codes.NOT_CODED},
-            Metadata("test_user", Metadata.get_call_location(), 1)
-        )
-
-        FoldTracedData.reconcile_boolean_keys("test_user", td_1, td_2, {"a", "b", "c", "d", "e"})
-
-        expected_dict = {"a": Codes.TRUE, "b": Codes.TRUE, "c": Codes.FALSE, "d": Codes.TRUE, "e": Codes.FALSE}
-        self.assertDictEqual(dict(td_1.items()), expected_dict)
-        self.assertDictEqual(dict(td_2.items()), expected_dict)
-
     def test_reconcile_yes_no_keys(self):
         td_1 = TracedData(
             {"a": Codes.YES, "b": Codes.NO, "c": Codes.YES, "d": Codes.NO, "e": Codes.NOT_CODED, "f": Codes.NOT_CODED,

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -116,18 +116,6 @@ class TestFoldTracedData(unittest.TestCase):
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
-    def test_set_keys_to_value(self):
-        td = TracedData(
-            {"msg1": "abc", "msg2": "xy", "x": 4},
-            Metadata("test_user", Metadata.get_call_location(), 0)
-        )
-
-        FoldTracedData.set_keys_to_value("test_user", td, {"msg1"})
-        self.assertDictEqual(dict(td.items()), {"msg1": "MERGED", "msg2": "xy", "x": 4})
-
-        FoldTracedData.set_keys_to_value("test_user", td, {"msg2", "x"}, value="----")
-        self.assertDictEqual(dict(td.items()), {"msg1": "MERGED", "msg2": "----", "x": "----"})
-
     def test_fold_traced_data(self):
         td_1_dict = {
                 "equal_1": 4, "equal_2": "xyz",

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -80,36 +80,6 @@ class TestFoldTracedData(unittest.TestCase):
         self.assertDictEqual(dict(folded_data[1].items()), {"x": "bcd"})
         self.assertDictEqual(dict(folded_data[2].items()), {"x": "e"})
 
-    def test_assert_equal_keys_equal(self):
-        td_1 = TracedData(
-            {"eq1": "5", "eq2": "6", "ne": "10"},
-            Metadata("test_user", Metadata.get_call_location(), 0)
-        )
-
-        td_2_expect_pass = TracedData(
-            {"eq1": "5", "eq2": "6", "ne": "13"},
-            Metadata("test_user", Metadata.get_call_location(), 1)
-        )
-
-        td_2_expect_fail = TracedData(
-            {"eq1": "5", "eq2": "7", "ne": "10"},
-            Metadata("test_user", Metadata.get_call_location(), 1)
-        )
-
-        # This test is considered successful if no assertion is raised
-        FoldTracedData.assert_equal_keys_equal(td_1, td_2_expect_pass, {"eq1", "eq2"})
-
-        try:
-            FoldTracedData.assert_equal_keys_equal(td_1, td_2_expect_fail, {"eq1", "eq2"})
-            self.fail("No AssertionError raised")
-        except AssertionError as e:
-            if str(e) == "No AssertionError raised":
-                raise e
-
-            self.assertEqual(str(e),
-                             "Key 'eq2' should be the same in both td_1 and td_2 but is "
-                             "different (has values '6' and '7' respectively)")
-
     def test_reconcile_missing_values(self):
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -36,6 +36,10 @@ class TestReconciliationFunctions(unittest.TestCase):
         self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_1, Codes.MATRIX_0), Codes.MATRIX_1)
         self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_0, Codes.MATRIX_0), Codes.MATRIX_0)
 
+    def test_control_code(self):
+        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
+        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
+
 
 class TestFoldTracedData(unittest.TestCase):
     @staticmethod

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -112,10 +112,6 @@ class TestFoldTracedData(unittest.TestCase):
         self.assertDictEqual(dict(folded_data[1].items()), {"x": "bcd"})
         self.assertDictEqual(dict(folded_data[2].items()), {"x": "e"})
 
-    def test_reconcile_missing_values(self):
-        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
-        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
-
     def test_fold_traced_data(self):
         td_1_dict = {
                 "equal_1": 4, "equal_2": "xyz",

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -22,6 +22,10 @@ class TestReconciliationFunctions(unittest.TestCase):
                              "Values should be the same but are different "
                              "(differing values were '6' and '7')")
 
+    def test_control_code(self):
+        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
+        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
+
     def test_concatenate(self):
         self.assertEqual(FoldStrategies.concatenate("abc", "def"), "abc;def")
         self.assertEqual(FoldStrategies.concatenate("abc", ""), "abc;")
@@ -40,10 +44,6 @@ class TestReconciliationFunctions(unittest.TestCase):
         self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_0, Codes.MATRIX_1), Codes.MATRIX_1)
         self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_1, Codes.MATRIX_0), Codes.MATRIX_1)
         self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_0, Codes.MATRIX_0), Codes.MATRIX_0)
-
-    def test_control_code(self):
-        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
-        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
 
 class TestFoldTracedData(unittest.TestCase):

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -22,6 +22,14 @@ class TestReconciliationFunctions(unittest.TestCase):
                              "Values should be the same but are different "
                              "(differing values were '6' and '7')")
 
+    def test_concatenate(self):
+        self.assertEqual(FoldStrategies.concatenate("abc", "def"), "abc;def")
+        self.assertEqual(FoldStrategies.concatenate("abc", ""), "abc;")
+        self.assertEqual(FoldStrategies.concatenate("abc", None), "abc")
+        self.assertEqual(FoldStrategies.concatenate("", "def"), ";def")
+        self.assertEqual(FoldStrategies.concatenate(None, "def"), "def")
+        self.assertEqual(FoldStrategies.concatenate(None, None), None)
+
 
 class TestFoldTracedData(unittest.TestCase):
     @staticmethod

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -116,7 +116,7 @@ class TestFoldTracedData(unittest.TestCase):
         td_1_dict = {
                 "equal_1": 4, "equal_2": "xyz",
                 "concat": "abc",
-                "matrix_1": Codes.MATRIX_0, "matrix_2": Codes.STOP,
+                "matrix_1": Codes.MATRIX_0, "matrix_2": Codes.MATRIX_0,
                 "bool_1": Codes.FALSE, "bool_2": Codes.TRUE,
                 "yes_no_1": Codes.YES, "yes_no_2": Codes.YES,
                 "other_1": "other 1", "other_2": "other 2"
@@ -157,7 +157,7 @@ class TestFoldTracedData(unittest.TestCase):
             {
                 "equal_1": 4, "equal_2": "xyz",
                 "concat": "abc;def",
-                "matrix_1": Codes.MATRIX_1, "matrix_2": Codes.STOP,
+                "matrix_1": Codes.MATRIX_1, "matrix_2": Codes.MATRIX_0,
                 "bool_1": Codes.TRUE, "bool_2": Codes.TRUE,
                 "yes_no_1": Codes.YES, "yes_no_2": FoldStrategies.AMBIVALENT_BINARY_VALUE,
             }

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -30,6 +30,12 @@ class TestReconciliationFunctions(unittest.TestCase):
         self.assertEqual(FoldStrategies.concatenate(None, "def"), "def")
         self.assertEqual(FoldStrategies.concatenate(None, None), None)
 
+    def test_matrix(self):
+        self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_1, Codes.MATRIX_1), Codes.MATRIX_1)
+        self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_0, Codes.MATRIX_1), Codes.MATRIX_1)
+        self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_1, Codes.MATRIX_0), Codes.MATRIX_1)
+        self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_0, Codes.MATRIX_0), Codes.MATRIX_0)
+
 
 class TestFoldTracedData(unittest.TestCase):
     @staticmethod

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -116,31 +116,6 @@ class TestFoldTracedData(unittest.TestCase):
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
-    def test_reconcile_binary_keys(self):
-        td_1 = TracedData(
-            {"a": "integrate", "b": "return", "c": FoldTracedData.AMBIVALENT_BINARY_VALUE,
-             "d": FoldTracedData.AMBIVALENT_BINARY_VALUE, "e": "integrate", "f": Codes.NOT_CODED,
-             "g": Codes.STOP, "h": Codes.NOT_CODED, "i": Codes.BOTH},
-            Metadata("test_user", Metadata.get_call_location(), 0)
-        )
-
-        td_2 = TracedData(
-            {"a": "integrate", "b": "integrate", "c": "return", "d": FoldTracedData.AMBIVALENT_BINARY_VALUE,
-             "e": FoldTracedData.AMBIVALENT_BINARY_VALUE, "f": Codes.NOT_CODED,
-             "g": Codes.NOT_CODED, "h": "integrate", "i": "integrate"},
-            Metadata("test_user", Metadata.get_call_location(), 1)
-        )
-
-        FoldTracedData.reconcile_binary_keys("test_user", td_1, td_2, {"a", "b", "c", "d", "e", "f", "g", "h", "i"})
-
-        expected_dict = {"a": "integrate", "b": FoldTracedData.AMBIVALENT_BINARY_VALUE,
-                         "c": FoldTracedData.AMBIVALENT_BINARY_VALUE, "d": FoldTracedData.AMBIVALENT_BINARY_VALUE,
-                         "e": FoldTracedData.AMBIVALENT_BINARY_VALUE, "f": Codes.NOT_CODED,
-                         "g": Codes.STOP, "h": "integrate", "i": FoldTracedData.AMBIVALENT_BINARY_VALUE}
-
-        self.assertDictEqual(dict(td_1.items()), expected_dict)
-        self.assertDictEqual(dict(td_2.items()), expected_dict)
-
     def test_set_keys_to_value(self):
         td = TracedData(
             {"msg1": "abc", "msg2": "xy", "x": 4},

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -45,6 +45,15 @@ class TestReconciliationFunctions(unittest.TestCase):
         self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_1, Codes.MATRIX_0), Codes.MATRIX_1)
         self.assertEqual(FoldStrategies.matrix(Codes.MATRIX_0, Codes.MATRIX_0), Codes.MATRIX_0)
 
+    def test_yes_no_amb(self):
+        self.assertEqual(FoldStrategies.yes_no_amb(Codes.YES, Codes.YES), Codes.YES)
+        self.assertEqual(FoldStrategies.yes_no_amb(Codes.NO, Codes.NO), Codes.NO)
+        self.assertEqual(FoldStrategies.yes_no_amb(Codes.YES, Codes.NO), FoldStrategies.AMBIVALENT_BINARY_VALUE)
+        self.assertEqual(FoldStrategies.yes_no_amb(Codes.NOT_CODED, Codes.NOT_CODED), Codes.NOT_CODED)
+
+        # TODO: Check that this test case is desired
+        self.assertEqual(FoldStrategies.yes_no_amb(Codes.NOT_REVIEWED, Codes.YES), Codes.YES)
+
 
 class TestFoldTracedData(unittest.TestCase):
     @staticmethod

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -23,8 +23,8 @@ class TestReconciliationFunctions(unittest.TestCase):
                              "(differing values were '6' and '7')")
 
     def test_control_code(self):
-        self.assertEqual(FoldStrategies.control_code(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
-        self.assertEqual(FoldStrategies.control_code(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
+        self.assertEqual(FoldStrategies.control_code_by_precedence(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
+        self.assertEqual(FoldStrategies.control_code_by_precedence(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
     def test_concatenate(self):
         self.assertEqual(FoldStrategies.concatenate("abc", "def"), "abc;def")

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -160,25 +160,5 @@ class TestFoldTracedData(unittest.TestCase):
                 "matrix_1": Codes.MATRIX_1, "matrix_2": Codes.STOP,
                 "bool_1": Codes.TRUE, "bool_2": Codes.TRUE,
                 "yes_no_1": Codes.YES, "yes_no_2": FoldStrategies.AMBIVALENT_BINARY_VALUE,
-                # "other_1": "MERGED", "other_2": "MERGED"
-            }
-        )
-        
-        return
-
-        # Test folding only some keys
-        folded_td = FoldTracedData.fold_traced_data(
-            "test_user", td_1, td_2, matrix_keys={"matrix_1"}, bool_keys={"bool_1", "bool_2"}
-        )
-
-        self.assertDictEqual(
-            dict(folded_td.items()),
-            {
-                "equal_1": "MERGED", "equal_2": "MERGED",
-                "concat": "MERGED",
-                "matrix_1": Codes.MATRIX_1, "matrix_2": "MERGED",
-                "bool_1": Codes.TRUE, "bool_2": Codes.TRUE,
-                "yes_no_1": "MERGED", "yes_no_2": "MERGED",
-                "other_1": "MERGED", "other_2": "MERGED"
             }
         )

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -107,26 +107,6 @@ class TestFoldTracedData(unittest.TestCase):
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
-    def test_reconcile_yes_no_keys(self):
-        td_1 = TracedData(
-            {"a": Codes.YES, "b": Codes.NO, "c": Codes.YES, "d": Codes.NO, "e": Codes.NOT_CODED, "f": Codes.NOT_CODED,
-             "g": Codes.BOTH, "h": Codes.STOP},
-            Metadata("test_user", Metadata.get_call_location(), 0)
-        )
-
-        td_2 = TracedData(
-            {"a": Codes.YES, "b": Codes.YES, "c": Codes.NO, "d": Codes.NO, "e": Codes.YES, "f": Codes.NOT_CODED,
-             "g": Codes.YES, "h": Codes.YES},
-            Metadata("test_user", Metadata.get_call_location(), 1)
-        )
-
-        FoldTracedData.reconcile_yes_no_keys("test_user", td_1, td_2, {"a", "b", "c", "d", "e", "f", "g", "h"})
-
-        expected_dict = {"a": Codes.YES, "b": Codes.BOTH, "c": Codes.BOTH, "d": Codes.NO, "e": Codes.YES,
-                         "f": Codes.NOT_CODED, "g": Codes.BOTH, "h": Codes.STOP}
-        self.assertDictEqual(dict(td_1.items()), expected_dict)
-        self.assertDictEqual(dict(td_2.items()), expected_dict)
-
     def test_reconcile_binary_keys(self):
         td_1 = TracedData(
             {"a": "integrate", "b": "return", "c": FoldTracedData.AMBIVALENT_BINARY_VALUE,

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -98,28 +98,6 @@ class TestFoldTracedData(unittest.TestCase):
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
-    def test_reconcile_matrix_keys(self):
-        td_1 = TracedData(
-            {"a": Codes.MATRIX_0, "b": Codes.MATRIX_1, Codes.NOT_REVIEWED: Codes.MATRIX_1,
-             Codes.NOT_CODED: Codes.MATRIX_1, "c": Codes.STOP},
-            Metadata("test_user", Metadata.get_call_location(), 0)
-        )
-
-        td_2 = TracedData(
-            {"a": Codes.MATRIX_0, "b": Codes.MATRIX_0, Codes.NOT_REVIEWED: Codes.MATRIX_0,
-             Codes.NOT_CODED: Codes.MATRIX_0, "c": Codes.MATRIX_0},
-            Metadata("test_user", Metadata.get_call_location(), 1)
-        )
-
-        # TODO: Update dictionaries above to test for the various cases of missing data
-
-        FoldTracedData.reconcile_matrix_keys("test_user", td_1, td_2, td_1.keys())
-
-        expected_dict = {"a": Codes.MATRIX_0, "b": Codes.MATRIX_1, Codes.NOT_REVIEWED: Codes.MATRIX_1,
-                         Codes.NOT_CODED: Codes.MATRIX_0, "c": Codes.STOP}
-        self.assertDictEqual(dict(td_1.items()), expected_dict)
-        self.assertDictEqual(dict(td_2.items()), expected_dict)
-
     def test_reconcile_boolean_keys(self):
         td_1 = TracedData(
             {"a": Codes.TRUE, "b": Codes.FALSE, "c": Codes.FALSE, "d": Codes.NOT_CODED, "e": Codes.NOT_CODED},

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -92,30 +92,6 @@ class TestFoldTracedData(unittest.TestCase):
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
         self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
-    def test_reconcile_keys_by_concatenation(self):
-        def make_tds():
-            td_1 = TracedData(
-                {"msg1": "abc", "msg2": "xy", "x": 4},
-                Metadata("test_user", Metadata.get_call_location(), 0)
-            )
-
-            td_2 = TracedData(
-                {"msg1": "def", "msg2": "xy", "x": 5},
-                Metadata("test_user", Metadata.get_call_location(), 1)
-            )
-
-            return td_1, td_2
-
-        td_1, td_2 = make_tds()
-        FoldTracedData.reconcile_keys_by_concatenation("test_user", td_1, td_2, {"msg1", "msg2"})
-        self.assertDictEqual(dict(td_1.items()), {"msg1": "abc;def", "msg2": "xy;xy", "x": 4})
-        self.assertDictEqual(dict(td_2.items()), {"msg1": "abc;def", "msg2": "xy;xy", "x": 5})
-
-        td_1, td_2 = make_tds()
-        FoldTracedData.reconcile_keys_by_concatenation("test_user", td_1, td_2, {"msg1", "msg2"}, concat_delimiter="--")
-        self.assertDictEqual(dict(td_1.items()), {"msg1": "abc--def", "msg2": "xy--xy", "x": 4})
-        self.assertDictEqual(dict(td_2.items()), {"msg1": "abc--def", "msg2": "xy--xy", "x": 5})
-
     def test_reconcile_matrix_keys(self):
         td_1 = TracedData(
             {"a": Codes.MATRIX_0, "b": Codes.MATRIX_1, Codes.NOT_REVIEWED: Codes.MATRIX_1,

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -23,8 +23,8 @@ class TestReconciliationFunctions(unittest.TestCase):
                              "(differing values were '6' and '7')")
 
     def test_control_code(self):
-        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
-        self.assertEqual(FoldTracedData.reconcile_missing_values(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
+        self.assertEqual(FoldStrategies.control_code(Codes.TRUE_MISSING, Codes.NOT_CODED), Codes.NOT_CODED)
+        self.assertEqual(FoldStrategies.control_code(Codes.STOP, Codes.NOT_CODED), Codes.STOP)
 
     def test_concatenate(self):
         self.assertEqual(FoldStrategies.concatenate("abc", "def"), "abc;def")


### PR DESCRIPTION
This should make the fold functions easier to use, by aligning the function signature with how we think about the problem ("which strategy for this key?" rather than "which keys for this strategy?"), more extensible, by allowing users to plug in custom fold strategies, and simplifies the overall implementation by separating the fold strategies from the boilerplate key iteration logic.

This PR also lays the foundations for adding new fold strategies which can operate over labels, which will be needed to automate the analysis of the individuals traced data.

Old folding routines which are no longer necessary have been removed rather than migrated. Those that have been kept have been adapted from the previous implementations and their test cases.

This PR has been tested on a subset of OCHA and confirmed the outputs are the same when run over real data. You can see the minimal work required to update a pipeline to use this new interface here: https://github.com/AfricasVoices/Project-OCHA/pull/61