### PR TITLE
Normalise label scheme ids *at the end* when importing from Coda in multi coded mode

### DIFF
--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -352,6 +352,16 @@ class TracedDataCodaV2IO(object):
                         Metadata(user, Metadata.get_call_location(), time.time())
                     )
 
+                # Normalise the scheme ids of all the imported labels
+                labels = td.get(coded_key)
+                for label in labels:
+                    assert label["SchemeID"].startswith(scheme.scheme_id)
+                    label["SchemeID"] = scheme.scheme_id
+                td.append_data(
+                    {coded_key: [label for label in labels]},
+                    Metadata(user, Metadata.get_call_location(), time.time())
+                )
+
 
 class TracedDataCSVIO(object):
     @staticmethod

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -353,12 +353,12 @@ class TracedDataCodaV2IO(object):
                     )
 
                 # Normalise the scheme ids of all the imported labels
-                labels = td.get(coded_key)
+                labels = [Label.from_dict(d) for d in td[coded_key]]
                 for label in labels:
-                    assert label["SchemeID"].startswith(scheme.scheme_id)
-                    label["SchemeID"] = scheme.scheme_id
+                    assert label.scheme_id.startswith(scheme.scheme_id)
+                    label.scheme_id = scheme.scheme_id
                 td.append_data(
-                    {coded_key: [label for label in labels]},
+                    {coded_key: [label.to_dict() for label in labels]},
                     Metadata(user, Metadata.get_call_location(), time.time())
                 )
 


### PR DESCRIPTION
(Compare with https://github.com/AfricasVoices/CoreDataModules/pull/159, which normalises much earlier, and see the discussion there for why I prefer this approach instead)