### PR TITLE
Add FoldStrategies.fold_yes_no_amb_label

### DIFF
--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -211,6 +211,19 @@ class Code:
             validators.validate_list(self.match_values, "match_values")
             for i, match_value in enumerate(self.match_values):
                 validators.validate_string(match_value, f"match_values[{i}]")
+                
+    def has_match_value(self, match_value):
+        """
+        Returns whether the requested match_value is present in this code's match_values.
+
+        :param match_value: Value to search for in this code.
+        :type match_value: str
+        :return: Whether the requested match_value is present in this code's match_values.
+        :rtype: boolean
+        """
+        if self.match_values is None:
+            return False
+        return match_value in self.match_values
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -204,6 +204,22 @@ class FoldStrategies(object):
 
     @classmethod
     def yes_no_amb_label(cls, code_scheme, x, y):
+        """
+        Folds yes/no/ambivalent labels.
+        
+        :param code_scheme: Code scheme for the labels which are being folded.
+        :type code_scheme: core_data_modules.data_models.CodeScheme
+        :param x: Serialised core_data_modules.data_models.Label to fold.
+        :type x: dict
+        :param y: Serialised core_data_modules.data_models.Label to fold.
+        :type y: dict
+        :return: Folded control label if both labels are for control codes,
+                 the normal label if one label is for a control code and the other for a normal code,
+                 a yes label if both inputs have match values Codes.YES,
+                 a no label if both inputs have match values Codes.NO,
+                 otherwise creates a new label from the Codes.AMBIVALENT code in the code_scheme.
+        :rtype: 
+        """
         # Ensure the labels belong to this code scheme
         assert x["SchemeID"] == code_scheme.scheme_id
         assert y["SchemeID"] == code_scheme.scheme_id

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -140,7 +140,7 @@ class FoldStrategies(object):
                  the normal code if one code is a control code and the other a normal code,
                  Codes.YES if both inputs are Codes.YES,
                  Codes.NO if both inputs are Codes.NO,
-                 otherwise cls.AMBIVALENT_BINARY_VALUE.
+                 otherwise Codes.AMBIVALENT.
         :rtype: str
         """
         assert x in {Codes.YES, Codes.NO, Codes.AMBIVALENT} or x in Codes.CONTROL_CODES
@@ -162,8 +162,8 @@ class FoldStrategies(object):
     @classmethod
     def control_label_by_precedence(cls, code_scheme, x, y):
         """
-        Folds two control labels, by choosing the label with the control code of the highest precedence.
-        
+        Folds control labels, by choosing the label with the control code of the highest precedence.
+
         The precedence order for control codes is defined as follows (highest precedence listed first):
          - Codes.STOP
          - Codes.CODING_ERROR

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -202,10 +202,6 @@ class FoldStrategies(object):
         else:
             return y
 
-    @staticmethod
-    def _code_has_match_value(code, match_value):
-        return match_value in code.match_values
-
     @classmethod
     def yes_no_amb_label(cls, code_scheme, x, y):
         # Ensure the labels belong to this code scheme
@@ -217,10 +213,10 @@ class FoldStrategies(object):
         y_code = code_scheme.get_code_with_code_id(y["CodeID"])
         
         # Ensure the codes are either control codes or a Yes/No/Ambivalent code
-        assert x_code.code_type == CodeTypes.CONTROL or cls._code_has_match_value(x_code, Codes.YES) or \
-            cls._code_has_match_value(x_code, Codes.NO) or cls._code_has_match_value(x_code, Codes.AMBIVALENT)
-        assert y_code.code_type == CodeTypes.CONTROL or cls._code_has_match_value(y_code, Codes.YES) or \
-            cls._code_has_match_value(y_code, Codes.NO) or cls._code_has_match_value(y_code, Codes.AMBIVALENT)
+        assert x_code.code_type == CodeTypes.CONTROL or x_code.has_match_value(Codes.YES) or \
+            x_code.has_match_value(Codes.NO) or x_code.has_match_value(Codes.AMBIVALENT)
+        assert y_code.code_type == CodeTypes.CONTROL or y_code.has_match_value(Codes.YES) or \
+            y_code.has_match_value(Codes.NO) or y_code.has_match_value(Codes.AMBIVALENT)
 
         # Perform the actual label folding
         if x_code.code_type == CodeTypes.CONTROL and y_code.code_type == CodeTypes.CONTROL:
@@ -229,15 +225,16 @@ class FoldStrategies(object):
             return y
         elif y_code.code_type == CodeTypes.CONTROL:
             return x
-        elif Codes.AMBIVALENT in x_code.match_values:        
+        elif x_code.has_match_value(Codes.AMBIVALENT):
             return x
-        elif Codes.AMBIVALENT in y_code.match_values:
+        elif y_code.has_match_value(Codes.AMBIVALENT):
             return y
-        elif x == y:
+        elif x_code.code_id == y_code.code_id:
             return x
         else:
-            return CleaningUtils.make_label_from_cleaner_code(code_scheme, Codes.AMBIVALENT,
-                                                              Metadata.get_call_location())
+            return CleaningUtils.make_label_from_cleaner_code(
+                code_scheme, code_scheme.get_code_with_match_value(Codes.AMBIVALENT), Metadata.get_call_location()
+            ).to_dict()
 
 
 class FoldTracedData(object):

--- a/core_data_modules/traced_data/util/fold_traced_data.py
+++ b/core_data_modules/traced_data/util/fold_traced_data.py
@@ -161,6 +161,29 @@ class FoldStrategies(object):
 
     @classmethod
     def control_label_by_precedence(cls, code_scheme, x, y):
+        """
+        Folds two control labels, by choosing the label with the control code of the highest precedence.
+        
+        The precedence order for control codes is defined as follows (highest precedence listed first):
+         - Codes.STOP
+         - Codes.CODING_ERROR
+         - Codes.NOT_REVIEWED
+         - Codes.NOT_INTERNALLY_CONSISTENT
+         - Codes.NOT_CODED
+         - Codes.TRUE_MISSING
+         - Codes.SKIPPED
+         - Codes.WRONG_SCHEME
+         - Codes.NOISE_OTHER_CHANNEL
+        
+        :param code_scheme: Code scheme for the labels which are being folded.
+        :type code_scheme: core_data_modules.data_models.CodeScheme
+        :param x: Serialised core_data_modules.data_models.Label to fold.
+        :type x: dict
+        :param y: Serialised core_data_modules.data_models.Label to fold.
+        :type y: dict
+        :return: Serialised core_data_modules.data_models.Label with the control code of the highest precedence.
+        :rtype: dict
+        """
         # Ensure the labels belong to this code scheme
         assert x["SchemeID"] == code_scheme.scheme_id
         assert y["SchemeID"] == code_scheme.scheme_id

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -79,6 +79,50 @@ class TestReconciliationFunctions(unittest.TestCase):
         self.assertEqual(FoldStrategies.control_label_by_precedence(scheme_1, na_label, na_label_2), na_label)
         self.assertEqual(FoldStrategies.control_label_by_precedence(scheme_1, stop_label, nc_label), stop_label)
 
+    def test_yes_no_amb_label(self):
+        na_code = Code("code-NA", CodeTypes.CONTROL, "NA", -10, "NA", True, control_code=Codes.TRUE_MISSING)
+        nr_code = Code("code-NR", CodeTypes.CONTROL, "NR", -20, "NR", True, control_code=Codes.NOT_REVIEWED)
+        nc_code = Code("code-NC", CodeTypes.CONTROL, "NC", -30, "NC", True, control_code=Codes.NOT_CODED)
+        stop_code = Code("code-STOP", CodeTypes.CONTROL, "STOP", -40, "STOP", True, control_code=Codes.STOP)
+        normal_1_code = Code("code-normal-1", CodeTypes.NORMAL, "Normal 1", 1, "normal_1", True)
+        yes_code = Code("code-yes", CodeTypes.NORMAL, "Yes", 5, "yes", True, match_values=[Codes.YES])
+        no_code = Code("code-no", CodeTypes.NORMAL, "No", 5, "no", True, match_values=[Codes.NO])
+        amb_code = Code("code-amb", CodeTypes.NORMAL, "Ambivalent", 5, "amb", True, match_values=[Codes.AMBIVALENT])
+        question_code = Code("code-question", CodeTypes.META, "Question", 10, "question", True, meta_code=Codes.QUESTION)
+
+        scheme_1 = CodeScheme("scheme-1", "Scheme 1", "1",
+                              [na_code, nr_code, nc_code, stop_code, normal_1_code,
+                               yes_code, no_code, amb_code, question_code])
+
+        na_label = Label("scheme-1", "code-NA", "2019-10-01T12:20:14Z", Origin("x", "test", "automatic")).to_dict()
+        na_label_scheme_2 = Label("scheme-2", "code-NA", "2019-10-01T12:21:19Z", Origin("x", "test", "automatic")).to_dict()
+        nr_label = Label("scheme-1", "code-NR", "2019-10-01T12:20:14Z", Origin("x", "test", "automatic")).to_dict()
+        nc_label = Label("scheme-1", "code-NC", "2019-10-01T12:30:00Z", Origin("x", "test", "automatic")).to_dict()
+        question_label = Label("scheme-1", "code-question", "2019-10-01T14:00:00Z", Origin("x", "test", "automatic")).to_dict()
+        yes_label = Label("scheme-1", "code-yes", "2019-10-01T19:00:00Z", Origin("x", "test", "automatic")).to_dict()
+        yes_label_2 = Label("scheme-1", "code-yes", "2019-10-01T20:00:00Z", Origin("x", "test", "automatic")).to_dict()
+        no_label = Label("scheme-1", "code-no", "2019-10-01T20:00:00Z", Origin("x", "test", "automatic")).to_dict()
+        amb_label = Label("scheme-1", "code-amb", "2019-10-01T21:00:00Z", Origin("x", "test", "automatic")).to_dict()
+        normal_1_label = Label("scheme-1", "code-normal-1", "2019-10-01T12:20:14Z",
+                               Origin("x", "test", "automatic")).to_dict()
+        
+        # Test labels not part of this code scheme
+        self.assertRaises(AssertionError, lambda: FoldStrategies.yes_no_amb_label(scheme_1, na_label, na_label_scheme_2))
+
+        # Ensure labels that are not control codes or yes/no/ambivalent rejected
+        self.assertRaises(AssertionError, lambda: FoldStrategies.yes_no_amb_label(scheme_1, question_label, na_label))
+        self.assertRaises(AssertionError, lambda: FoldStrategies.yes_no_amb_label(scheme_1, normal_1_label, na_label))
+
+        # Test some valid combinations
+        self.assertEqual(FoldStrategies.yes_no_amb_label(scheme_1, yes_label, yes_label), yes_label)
+        self.assertEqual(FoldStrategies.yes_no_amb_label(scheme_1, yes_label_2, yes_label), yes_label_2)
+        self.assertEqual(FoldStrategies.yes_no_amb_label(scheme_1, no_label, no_label), no_label)
+        self.assertEqual(FoldStrategies.yes_no_amb_label(scheme_1, yes_label, no_label)["CodeID"], amb_label["CodeID"])
+        self.assertEqual(FoldStrategies.yes_no_amb_label(scheme_1, nc_label, nc_label), nc_label)
+
+        # TODO: Check that this test case is desired
+        self.assertEqual(FoldStrategies.yes_no_amb_label(scheme_1, nr_label, yes_label), yes_label)
+        
 
 class TestFoldTracedData(unittest.TestCase):
     @staticmethod

--- a/tests/traced_data/util/test_fold_traced_data.py
+++ b/tests/traced_data/util/test_fold_traced_data.py
@@ -1,6 +1,8 @@
 import unittest
 
 from core_data_modules.cleaners import Codes
+from core_data_modules.data_models import Code, CodeScheme, Label, Origin
+from core_data_modules.data_models.code_scheme import CodeTypes
 from core_data_modules.traced_data import Metadata, TracedData
 from core_data_modules.traced_data.util import FoldTracedData
 from core_data_modules.traced_data.util.fold_traced_data import FoldStrategies
@@ -53,6 +55,29 @@ class TestReconciliationFunctions(unittest.TestCase):
 
         # TODO: Check that this test case is desired
         self.assertEqual(FoldStrategies.yes_no_amb(Codes.NOT_REVIEWED, Codes.YES), Codes.YES)
+
+    def test_control_label_by_precedence(self):
+        na_code = Code("code-NA", CodeTypes.CONTROL, "NA", -10, "NA", True, control_code=Codes.TRUE_MISSING)
+        nc_code = Code("code-NC", CodeTypes.CONTROL, "NC", -30, "NC", True, control_code=Codes.NOT_CODED)
+        stop_code = Code("code-STOP", CodeTypes.CONTROL, "STOP", -40, "STOP", True, control_code=Codes.STOP)
+        normal_1_code = Code("code-normal-1", CodeTypes.NORMAL, "Normal 1", 1, "normal_1", True)
+        
+        scheme_1 = CodeScheme("scheme-1", "Scheme 1", "1", [na_code, nc_code, stop_code, normal_1_code])
+        
+        na_label = Label("scheme-1", "code-NA", "2019-10-01T12:20:14Z", Origin("x", "test", "automatic")).to_dict()
+        nc_label = Label("scheme-1", "code-NC", "2019-10-01T12:30:00Z", Origin("x", "test", "automatic")).to_dict()
+        stop_label = Label("scheme-1", "code-STOP", "2019-10-01T12:30:00Z", Origin("x", "test", "automatic")).to_dict()
+        na_label_2 = Label("scheme-1", "code-NA", "2019-10-01T13:00:00Z", Origin("x", "test", "automatic")).to_dict()
+        normal_1_label = Label("scheme-1", "code-normal-1", "2019-10-01T12:20:14Z", Origin("x", "test", "automatic")).to_dict()
+
+        # Test normal codes rejected
+        self.assertRaises(AssertionError,
+                          lambda: FoldStrategies.control_label_by_precedence(scheme_1, na_label, normal_1_label))
+        
+        # Test some control code combinations
+        self.assertEqual(FoldStrategies.control_label_by_precedence(scheme_1, na_label, nc_label), nc_label)
+        self.assertEqual(FoldStrategies.control_label_by_precedence(scheme_1, na_label, na_label_2), na_label)
+        self.assertEqual(FoldStrategies.control_label_by_precedence(scheme_1, stop_label, nc_label), stop_label)
 
 
 class TestFoldTracedData(unittest.TestCase):


### PR DESCRIPTION
Review #163 first.

This allows us to fold yes/no/ambivalent labels.

There is a bit of refactoring of control_code_by_precedence here to de-duplicate the logic between that and the new control_label_by_precedence function, added here to support yes_no_amb_label.