### PR TITLE
De-duplicate labels when importing from Coda

### DIFF
--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -361,15 +361,15 @@ class TracedDataCodaV2IO(object):
                 # De-duplicate the imported labels by selecting the first label with each code id.
                 # This is required in cases where the same label was applied to this message under different columns
                 # of the same code scheme, and is possible now that we have normalised the scheme ids.
-                deduplicated_labels = []
+                unique_labels_by_code_id = []
                 seen_code_ids = set()
                 for label in labels:
                     if label.code_id not in seen_code_ids:
-                        deduplicated_labels.append(label)
+                        unique_labels_by_code_id.append(label)
                         seen_code_ids.add(label.code_id)
                 
                 td.append_data(
-                    {coded_key: [label.to_dict() for label in deduplicated_labels]},
+                    {coded_key: [label.to_dict() for label in unique_labels_by_code_id]},
                     Metadata(user, Metadata.get_call_location(), time.time())
                 )
 

--- a/core_data_modules/traced_data/io.py
+++ b/core_data_modules/traced_data/io.py
@@ -357,8 +357,19 @@ class TracedDataCodaV2IO(object):
                 for label in labels:
                     assert label.scheme_id.startswith(scheme.scheme_id)
                     label.scheme_id = scheme.scheme_id
+                    
+                # De-duplicate the imported labels by selecting the first label with each code id.
+                # This is required in cases where the same label was applied to this message under different columns
+                # of the same code scheme, and is possible now that we have normalised the scheme ids.
+                deduplicated_labels = []
+                seen_code_ids = set()
+                for label in labels:
+                    if label.code_id not in seen_code_ids:
+                        deduplicated_labels.append(label)
+                        seen_code_ids.add(label.code_id)
+                
                 td.append_data(
-                    {coded_key: [label.to_dict() for label in labels]},
+                    {coded_key: [label.to_dict() for label in deduplicated_labels]},
                     Metadata(user, Metadata.get_call_location(), time.time())
                 )
 

--- a/tests/traced_data/resources/coda_2_import_test_multi_coded.json
+++ b/tests/traced_data/resources/coda_2_import_test_multi_coded.json
@@ -172,6 +172,18 @@
           "OriginType": "Manual"
         },
         "Confidence": 1
+      },
+      {
+        "Checked": true,
+        "CodeID": "code-b8e40cba",
+        "DateTimeUTC": "2019-01-25T11:14:05.522Z",
+        "SchemeID": "Scheme-c4855fcb-1",
+        "Origin": {
+          "Name": "test_user",
+          "OriginID": "test_user_id",
+          "OriginType": "Manual"
+        },
+        "Confidence": 1
       }
     ]
   }

--- a/tests/traced_data/test_io.py
+++ b/tests/traced_data/test_io.py
@@ -329,15 +329,16 @@ class TestTracedDataCodaV2IO(unittest.TestCase):
             imported_code_ids.append([code["CodeID"] for code in td["msg_coded"]])
 
         expected_code_ids = [
-            {msg_scheme.get_code_with_match_value("food").code_id},
-            {msg_scheme.get_code_with_control_code(Codes.TRUE_MISSING).code_id},
-            {msg_scheme.get_code_with_match_value("food").code_id, msg_scheme.get_code_with_match_value("water").code_id},
-            {msg_scheme.get_code_with_control_code(Codes.TRUE_MISSING).code_id},
-            {msg_scheme.get_code_with_match_value("water").code_id},
-            {msg_scheme.get_code_with_control_code(Codes.NOT_CODED).code_id}
+            [msg_scheme.get_code_with_match_value("food").code_id],
+            [msg_scheme.get_code_with_control_code(Codes.TRUE_MISSING).code_id],
+            [msg_scheme.get_code_with_match_value("food").code_id, msg_scheme.get_code_with_match_value("water").code_id],
+            [msg_scheme.get_code_with_control_code(Codes.TRUE_MISSING).code_id],
+            [msg_scheme.get_code_with_match_value("water").code_id],
+            [msg_scheme.get_code_with_control_code(Codes.NOT_CODED).code_id]
         ]
 
         for x, y in zip(imported_code_ids, expected_code_ids):
+            self.assertEqual(len(x), len(y))
             self.assertSetEqual(set(x), set(y))
 
 


### PR DESCRIPTION
This de-duplicates labels in cases where the same label was applied to the same message in the code scheme, but in a different column of Coda when labelling in multi-coded mode.

These duplicates historically had no effect because of the conversion from labels to matrix representation before doing anything interesting with them. However, now that we're using the labels themselves in analysis, having these duplicates would complicate a lot of the code in later stages of the pipeline. This PR removes them.