### PR TITLE
Improve performance of Metadata.get_call_location

### DIFF
--- a/core_data_modules/traced_data/traced_data.py
+++ b/core_data_modules/traced_data/traced_data.py
@@ -50,12 +50,10 @@ class Metadata(object):
         :rtype: str
         """
         # Access the previous frame to find out where this function was called from.
-        # Setting context to 0 prevents collection of the surrounding lines in the source file, which substantially
-        # improves performance.
-        frame = inspect.getframeinfo(inspect.currentframe().f_back, context=0)
-        file_path = frame[0]
-        line_number = frame[1]
-        function_name = frame[2]
+        frame = inspect.currentframe().f_back
+        file_path = frame.f_code.co_filename
+        line_number = frame.f_lineno
+        function_name = frame.f_code.co_name
 
         return "{}:{}:{}".format(file_path, str(line_number), function_name)
 

--- a/core_data_modules/traced_data/traced_data.py
+++ b/core_data_modules/traced_data/traced_data.py
@@ -49,7 +49,7 @@ class Metadata(object):
         :return Caller location in the format 'path/to/file.py:line_number:function_name'
         :rtype: str
         """
-        # Access the previous frame to find out where this function was called from.
+        # Access the caller's stack frame to find out where this function was called from.
         frame = inspect.currentframe().f_back
         file_path = frame.f_code.co_filename
         line_number = frame.f_lineno

--- a/core_data_modules/traced_data/traced_data.py
+++ b/core_data_modules/traced_data/traced_data.py
@@ -46,15 +46,18 @@ class Metadata(object):
         """
         Returns the location where this function was called from.
 
-        :return Caller location in the format 'path/to/file.py:line:function_name'
+        :return Caller location in the format 'path/to/file.py:line_number:function_name'
         :rtype: str
         """
-        frame = inspect.stack()[1]  # Access the previous frame to find out where this function was called from.
-        f = frame[1]
-        line = frame[2]
-        name = frame[3]
+        # Access the previous frame to find out where this function was called from.
+        # Setting context to 0 prevents collection of the surrounding lines in the source file, which substantially
+        # improves performance.
+        frame = inspect.getframeinfo(inspect.currentframe().f_back, context=0)
+        file_path = frame[0]
+        line_number = frame[1]
+        function_name = frame[2]
 
-        return "{}:{}:{}".format(f, str(line), name)
+        return "{}:{}:{}".format(file_path, str(line_number), function_name)
 
     @staticmethod
     def get_function_location(func):


### PR DESCRIPTION
The existing approach, using inspect.stack(), is slow for two reasons:
1. inspect.stack() gets basic information about the current stack, which is really fast, and adds context by reading the relevant lines from the source file, which is really slow. Since this context isn't exported into our Metadata anywhere, this is an unnecessary slow-down.
2. inspect.stack() returns information about all the current frames in the stack, not just the one frame we're interested in, so again is spending retrieving information we're not interested in.

The new approach extracts only the information we care about, and only looks at the caller's stack frame (via the one for get_call_location) rather than the complete history.

In timing experiments on my laptop, this improves the speed of get_call_location() by approximately 500x.

Furthermore, experiments using a new python profiler (pyinstrument; I'll submit a PR to projects next week), show that get_call_location is one of our most expensive operations (along with TracedData reads), especially when importing labels from Coda, so this has a substantial impact on pipeline performance. As an example, OCHA in test mode typically takes about 38 minutes to run its generate_outputs stage. With this update, that time reduces to about 28 minutes, a speed-up of about 25%.