### PR TITLE
Add a cache to TracedData

### DIFF
--- a/core_data_modules/traced_data/traced_data.py
+++ b/core_data_modules/traced_data/traced_data.py
@@ -169,7 +169,7 @@ class TracedData(Mapping):
         self._sha = self._sha_with_prev(self._data, self._prev._sha)
         self._metadata = new_metadata
 
-        # If the cache exists, updated it with the latest values
+        # If the cache exists, update it with the latest values
         if self._cache is not None:
             for traced_values in filter(lambda v: type(v) == TracedData, new_data.values()):
                 if traced_values._cache is None:

--- a/core_data_modules/traced_data/traced_data.py
+++ b/core_data_modules/traced_data/traced_data.py
@@ -152,23 +152,21 @@ class TracedData(Mapping):
         :param new_metadata: Metadata about this update
         :type new_metadata: Metadata
         """
-        if self._cache is None:
-            self.regenerate_cache()
-
         self._prev = TracedData(self._data, self._metadata, self._prev)
         self._data = new_data
         self._sha = self._sha_with_prev(self._data, self._prev._sha)
         self._metadata = new_metadata
 
-        for traced_values in filter(lambda v: type(v) == TracedData, new_data.values()):
-            self._cache.update(traced_values.get_latest_cache())
+        if self._cache is not None:
+            for traced_values in filter(lambda v: type(v) == TracedData, new_data.values()):
+                self._cache.update(traced_values.get_latest_cache())
 
-        for key in new_data.keys():
-            if new_data[key] == self._TOMBSTONE_VALUE:
-                if key in self._cache:
-                    del self._cache[key]
-            else:
-                self._cache[key] = self._data[key]
+            for key in new_data.keys():
+                if new_data[key] == self._TOMBSTONE_VALUE:
+                    if key in self._cache:
+                        del self._cache[key]
+                else:
+                    self._cache[key] = self._data[key]
 
     def append_traced_data(self, key_of_appended, traced_data, new_metadata):
         """

--- a/core_data_modules/traced_data/traced_data.py
+++ b/core_data_modules/traced_data/traced_data.py
@@ -159,7 +159,10 @@ class TracedData(Mapping):
 
         if self._cache is not None:
             for traced_values in filter(lambda v: type(v) == TracedData, new_data.values()):
-                self._cache.update(traced_values.get_latest_cache())
+                if traced_values._cache is None:
+                    self._cache.update(traced_values.get_latest_cache())
+                else:
+                    self._cache.update(traced_values._cache)
 
             for key in new_data.keys():
                 if new_data[key] == self._TOMBSTONE_VALUE:

--- a/core_data_modules/traced_data/traced_data.py
+++ b/core_data_modules/traced_data/traced_data.py
@@ -1,6 +1,6 @@
 import inspect
 import time
-from collections import Mapping, KeysView, ValuesView, ItemsView, Iterator
+from collections import Mapping, KeysView, ValuesView, ItemsView
 
 from core_data_modules.util import TimeUtils
 from core_data_modules.util.sha_utils import SHAUtils
@@ -118,9 +118,30 @@ class TracedData(Mapping):
         self._data = data
         self._sha = self._sha_with_prev(data, None if _prev is None else _prev._sha)
         self._metadata = metadata
+        self._cache = None
 
     def get_sha(self):
         return self._sha
+
+    def get_latest_cache(self):
+        latest = dict()
+        if self._prev is not None:
+            latest.update(self._prev.get_latest_cache())
+
+        for traced_values in filter(lambda v: type(v) == TracedData, self._data.values()):
+            latest.update(traced_values.get_latest_cache())
+
+        for key in self._data.keys():
+            if self._data[key] == self._TOMBSTONE_VALUE:
+                if key in latest:
+                    del latest[key]
+            else:
+                latest[key] = self._data[key]
+
+        return latest
+
+    def regenerate_cache(self):
+        self._cache = self.get_latest_cache()
 
     def append_data(self, new_data, new_metadata):
         """
@@ -131,10 +152,23 @@ class TracedData(Mapping):
         :param new_metadata: Metadata about this update
         :type new_metadata: Metadata
         """
+        if self._cache is None:
+            self.regenerate_cache()
+
         self._prev = TracedData(self._data, self._metadata, self._prev)
         self._data = new_data
         self._sha = self._sha_with_prev(self._data, self._prev._sha)
         self._metadata = new_metadata
+
+        for traced_values in filter(lambda v: type(v) == TracedData, new_data.values()):
+            self._cache.update(traced_values.get_latest_cache())
+
+        for key in new_data.keys():
+            if new_data[key] == self._TOMBSTONE_VALUE:
+                if key in self._cache:
+                    del self._cache[key]
+            else:
+                self._cache[key] = self._data[key]
 
     def append_traced_data(self, key_of_appended, traced_data, new_metadata):
         """
@@ -213,61 +247,31 @@ class TracedData(Mapping):
         return SHAUtils.sha_dict({"data": cls._replace_traced_with_sha(data), "prev_sha": prev_sha})
 
     def __getitem__(self, key):
-        if key in self._data:
-            if self._data[key] == self._TOMBSTONE_VALUE:
-                raise KeyError(key)
-            return self._data[key]
+        if self._cache is None:
+            self.regenerate_cache()
 
-        for traced_values in filter(lambda v: type(v) == TracedData, self._data.values()):
-            if key in traced_values:
-                if traced_values[key] == self._TOMBSTONE_VALUE:
-                    raise KeyError(key)
-                return traced_values[key]
-
-        if self._prev is not None:
-            return self._prev[key]
-
-        raise KeyError(key)
+        return self._cache[key]
 
     def get(self, key, default=None):
-        if key in self._data:
-            if self._data[key] == self._TOMBSTONE_VALUE:
-                return default
-            return self._data[key]
+        if self._cache is None:
+            self.regenerate_cache()
 
-        for traced_values in filter(lambda v: type(v) == TracedData, self._data.values()):
-            if key in traced_values:
-                if traced_values[key] == self._TOMBSTONE_VALUE:
-                    return default
-                return traced_values[key]
-
-        if self._prev is not None:
-            return self._prev.get(key, default)
-
-        return default
+        return self._cache.get(key, default)
 
     def __len__(self):
         return sum(1 for _ in self)
 
     def __contains__(self, key):
-        if key in self._data:
-            if self._data[key] == self._TOMBSTONE_VALUE:
-                return False
-            return True
+        if self._cache is None:
+            self.regenerate_cache()
 
-        for traced_values in filter(lambda v: type(v) == TracedData, self._data.values()):
-            if key in traced_values:
-                if traced_values[key] == self._TOMBSTONE_VALUE:
-                    return False
-                return True
-
-        if self._prev is not None:
-            return key in self._prev
-
-        return False
+        return key in self._cache
 
     def __iter__(self):
-        return _TracedDataKeysIterator(self)
+        if self._cache is None:
+            self.regenerate_cache()
+
+        return iter(filter(lambda k: type(self._cache[k]) != TracedData, self._cache))
 
     def keys(self):
         return KeysView(self)
@@ -476,54 +480,3 @@ class TracedData(Mapping):
                 update_td,
                 Metadata(user, Metadata.get_call_location(), time.time())
             )
-
-
-# noinspection PyProtectedMember
-class _TracedDataKeysIterator(Iterator):
-    """Iterator over the keys of a TracedData object"""
-
-    def __init__(self, traced_data, seen_keys=None):
-        if seen_keys is None:
-            seen_keys = set()
-        self.traced_data = traced_data
-        self.next_keys = iter(traced_data._data)
-        self.next_traced_datas = []
-        self.seen_keys = seen_keys
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        while True:
-            # Search for a new key in the iterator for the current TracedData instance.
-            try:
-                while True:
-                    key = next(self.next_keys)
-
-                    if self.traced_data._data[key] == TracedData._TOMBSTONE_VALUE:
-                        self.seen_keys.add(key)
-                        continue
-
-                    # If this key points to another TracedData, add that TracedData to a queue of objects to return 
-                    # after returning the other keys
-                    if type(self.traced_data[key]) == TracedData:
-                        self.next_traced_datas.append(_TracedDataKeysIterator(self.traced_data[key], self.seen_keys))
-                        continue
-
-                    if key not in self.seen_keys:
-                        self.seen_keys.add(key)
-                        return key
-            except StopIteration:
-                # We ran out of keys with non-TracedData values.
-                # Now return all the keys from the TracedData values.
-                while len(self.next_traced_datas) > 0:
-                    try:
-                        return next(self.next_traced_datas[0])
-                    except StopIteration:
-                        self.next_traced_datas.pop(0)
-
-                # We ran out of keys which we haven't yet returned. Try the prev TracedData.
-                self.traced_data = self.traced_data._prev
-                if self.traced_data is None:
-                    raise StopIteration()
-                self.next_keys = iter(self.traced_data._data)

--- a/tests/traced_data/test_io.py
+++ b/tests/traced_data/test_io.py
@@ -460,7 +460,7 @@ class TestTracedDataJsonIO(unittest.TestCase):
 
         self.assertEqual(len(expected), len(imported))
         for x, y in zip(expected, imported):
-            x_attributes = {k: getattr(x, k) for k in dir(x) if not k.startswith("__") and not callable(getattr(x, k))}
-            y_attributes = {k: getattr(y, k) for k in dir(y) if not k.startswith("__") and not callable(getattr(y, k))}
+            x_attributes = {k: getattr(x, k) for k in dir(x) if not k.startswith("__") and not callable(getattr(x, k)) and k != "_cache"}
+            y_attributes = {k: getattr(y, k) for k in dir(y) if not k.startswith("__") and not callable(getattr(y, k)) and k != "_cache"}
 
             self.assertDictEqual(x_attributes, y_attributes)


### PR DESCRIPTION
The “cache” in TracedData is a dictionary containing all of the latest items. Caching the TracedData dramatically reduces the cost of lookups, because we only need to check a single dictionary (the cache), instead of searching all of the dictionaries throughout the entire TracedData history tree.

The implementation of caching used here is made under the constraint of not changing the TracedData API. Mostly this is straightforward - we maintain a cache in the newest TracedData but in none of the earlier TracedData objects in our history. When appending data to a TracedData, update the cache with the data being appended, and delete the cache in the previous TracedData objects (to save memory).
The only problem here is the copy() function, which doesn’t deep-copy the data, which means users can maintain a reference to a TracedData object that is in another TracedData's history. This is because (up to now) previous TracedData objects were immutable, so we could reuse history when copying to (a) copy faster and (b) save memory - we get a memory saving on pipelines of about 40-50% by doing this. The solution here is to delete caches when appending data, but lazily recreate them if they ever get requested again, which is why you’ll see the pattern ‘if cache is None: regenerate_cache()` a lot in the code.

Ironically, using a cache actually makes the implementation of many of the methods simpler. We’re trading complexity in the implementation of the methods for complexity in how those methods interact over time.

Finally, the reason we’re doing this, performance: On OCHA on Miranda, run-time when applying this PR reduces from approximately 38 minutes to 25 minutes, a speed-up of about 50%.