### PR TITLE
Check that each code id is unique within a scheme

### DIFF
--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -93,9 +93,12 @@ class CodeScheme(object):
         validators.validate_string(self.version, "version")
 
         validators.validate_list(self.codes, "codes")
+        code_ids = set()
         for i, code in enumerate(self.codes):
             assert isinstance(code, Code), f"self.codes[{i}] is not of type Code"
             code.validate()
+            assert code.code_id not in code_ids, f"Scheme contains two codes with id {code.code_id}"
+            code_ids.add(code.code_id)
 
         if self.documentation is not None:
             validators.validate_dict(self.documentation, "documentation")


### PR DESCRIPTION
This should remove the risk of copying a code (e.g. when doing code splits/merges, adding meta codes) and forgetting to update the code id in the copied code.