### PR TITLE
Fix some Kenya Codes

### DIFF
--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -149,7 +149,7 @@ class KenyaCodes(object):
     KESSES = "kesses"
     KHWISERO = "khwisero"
     KIAMBAA = "kiambaa"
-    KIAMBU = "kiambu"
+    KIAMBU = "kiambu"  # (Shadows county name "kiambu")
     KIBRA = "kibra"
     KIBWEZI_EAST = "kibwezi east"
     KIBWEZI_WEST = "kibwezi west"
@@ -209,7 +209,7 @@ class KenyaCodes(object):
     MACHAKOS_TOWN = "machakos town"
     MAGARINI = "magarini"
     MAKADARA = "makadara"
-    MAKUENI = "makueni"
+    MAKUENI = "makueni"  # (Shadows county name "makueni")
     MALAVA = "malava"
     MALINDI = "malindi"
     MANDERA_EAST = "mandera east"
@@ -329,7 +329,7 @@ class KenyaCodes(object):
     UGENYA = "ugenya"
     UGUNJA = "ugunja"
     URIRI = "uriri"
-    VIHIGA = "vihiga"
+    VIHIGA = "vihiga"  # (Shadows county name "vihiga")
     VOI = "voi"
     WAJIR_EAST = "wajir east"
     WAJIR_NORTH = "wajir north"

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -233,7 +233,7 @@ class KenyaCodes(object):
     MBEERE_SOUTH = "mbeere south"
     MBITA = "mbita"
     MBOONI = "mbooni"
-    MGOTIO = "mgotio"
+    MOGOTIO = "mogotio"
     MOIBEN = "moiben"
     MOLO = "molo"
     MOSOP = "mosop"
@@ -503,7 +503,7 @@ class KenyaCodes(object):
         BARINGO_NORTH: BARINGO,
         BARINGO_CENTRAL: BARINGO,
         BARINGO_SOUTH: BARINGO,
-        MGOTIO: BARINGO,
+        MOGOTIO: BARINGO,
         ELDAMA_RAVINE: BARINGO,
         LAIKIPIA_WEST: LAIKIPIA,
         LAIKIPIA_EAST: LAIKIPIA,

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -604,7 +604,6 @@ class KenyaCodes(object):
         KURIA_WEST: MIGORI,
         KURIA_EAST: MIGORI,
         BONCHARI: KISII,
-        BONCHARI: KISII,
         SOUTH_MUGIRANGO: KISII,
         BOMACHOGE_BORABU: KISII,
         BOBASI: KISII,

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -173,7 +173,7 @@ class KenyaCodes(object):
     KISUMU_CENTRAL = "kisumu central"
     KISUMU_EAST = "kisumu east"
     KISUMU_WEST = "kisumu west"
-    KITITU_CHACHE_SOUTH = "kititu chache south"
+    KITUTU_CHACHE_SOUTH = "kitutu chache south"
     KITUI_CENTRAL = "kitui central"
     KITUI_EAST = "kitui east"
     KITUI_RURAL = "kitui rural"
@@ -612,7 +612,7 @@ class KenyaCodes(object):
         NYARIBARI_MASABA: KISII,
         NYARIBARI_CHACHE: KISII,
         KITUTU_CHACHE_NORTH: KISII,
-        KITITU_CHACHE_SOUTH: KISII,
+        KITUTU_CHACHE_SOUTH: KISII,
         KITUTU_MASABA: NYAMIRA,
         WEST_MUGIRANGO: NYAMIRA,
         NORTH_MUGIRANGO: NYAMIRA,

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -123,6 +123,7 @@ class KenyaCodes(object):
     JOMVU = "jomvu"
     JUJA = "juja"
     KABETE = "kabete"
+    KABONDO_KASIPUL = "kabondo kasipul"
     KABUCHAI = "kabuchai"
     KACHELIBA = "kacheliba"
     KAITI = "kaiti"
@@ -142,7 +143,6 @@ class KenyaCodes(object):
     KARACHUONYO = "karachuonyo"
     KASARANI = "kasarani"
     KASIPUL = "kasipul"
-    KASIPUL_KABONDO = "kabondo kasipul"
     KATHIANI = "kathiani"
     KEIYO_NORTH = "keiyo north"
     KEIYO_SOUTH = "keiyo south"
@@ -589,7 +589,7 @@ class KenyaCodes(object):
         MUHORONI: KISUMU,
         NYAKACH: KISUMU,
         KASIPUL: HOMA_BAY,
-        KASIPUL_KABONDO : HOMA_BAY,
+        KABONDO_KASIPUL: HOMA_BAY,
         KARACHUONYO: HOMA_BAY,
         RANGWE: HOMA_BAY,
         HOMA_BAY_TOWN: HOMA_BAY,

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -69,7 +69,6 @@ class KenyaCodes(object):
     BOMET_CENTRAL = "bomet central"
     BOMET_EAST = "bomet east"
     BONCHARI = "bonchari"
-    BONCHARI = "bonchari"
     BONDO = "bondo"
     BORABU = "borabu"
     BUDALANGI = "budalangi"

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -112,7 +112,7 @@ class KenyaCodes(object):
     GITHUNGURI = "githunguri"
     HAMISI = "hamisi"
     HOMA_BAY_TOWN = "homa bay town"
-    IGAMBANG_OMBE = "igambang`ombe"
+    IGAMBANG_OMBE = "igambang'ombe"
     IGEMBE_CENTRAL = "igembe central"
     IGEMBE_NORTH = "igembe north"
     IGEMBE_SOUTH = "igembe south"

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -287,7 +287,7 @@ class KenyaCodes(object):
     ROYSAMBU = "roysambu"
     RUARAKA = "ruaraka"
     RUIRU = "ruiru"
-    RUNYEJES = "runyejes"
+    RUNYENJES = "runyenjes"
     SABATIA = "sabatia"
     SABOTI = "saboti"
     SAKU = "saku"
@@ -406,7 +406,7 @@ class KenyaCodes(object):
         IGAMBANG_OMBE: THARAKA_NITHI,
         THARAKA: THARAKA_NITHI,
         MANYATTA: EMBU,
-        RUNYEJES: EMBU,
+        RUNYENJES: EMBU,
         MBEERE_SOUTH: EMBU,
         MBEERE_NORTH: EMBU,
         MWINGI_NORTH: KITUI,

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -57,7 +57,7 @@ class KenyaCodes(object):
     ALEGO_USONGA = "alego usonga"
     AWENDO = "awendo"
     BAHATI = "bahati"
-    BALAMBALA = " balambala"
+    BALAMBALA = "balambala"
     BANISA = "banisa"
     BARINGO_CENTRAL = "baringo central"
     BARINGO_NORTH = "baringo north"

--- a/core_data_modules/cleaners/codes/kenya_codes.py
+++ b/core_data_modules/cleaners/codes/kenya_codes.py
@@ -342,7 +342,6 @@ class KenyaCodes(object):
     WUNDANYI = "wundanyi"
     YATTA = "yatta"
 
-    
     CONSTITUENCY_TO_COUNTY_MAP = {
         CHANGAMWE: MOMBASA,
         JOMVU: MOMBASA,


### PR DESCRIPTION
This corrects the spelling/location/formatting etc. of some of the KenyaCodes to match those defined in https://www.iebc.or.ke/docs/Physical_Locations_of_Constituency_Offices_in_Kenya_290_Constituencies.pdf.

Issues were found by attempting to validate the constituency scheme for AHADI against the constituencies defined in Core. We haven't encountered these on projects before because we haven't run nationwide before. There may still be other issues - manually checking all 290 constituencies + their counties would be extremely time consuming to do.

For the full list of changes, see the commit messages below.