### PR TITLE
Include CodeScheme id in scheme validation error messages

### DIFF
--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -94,11 +94,21 @@ class CodeScheme(object):
 
         validators.validate_list(self.codes, "codes")
         code_ids = set()
+        numeric_values = set()
+        string_values = set()
         for i, code in enumerate(self.codes):
             assert isinstance(code, Code), f"self.codes[{i}] is not of type Code"
             code.validate()
-            assert code.code_id not in code_ids, f"Scheme contains two codes with id {code.code_id}"
+
+            assert code.code_id not in code_ids, \
+                f"Scheme contains two codes with id {code.code_id}"
+            assert code.numeric_value not in numeric_values, \
+                f"Scheme contains two codes with numeric value {code.numeric_value}"
+            assert code.string_value not in string_values, \
+                f"Scheme contains two codes with string value {code.string_value}"
             code_ids.add(code.code_id)
+            numeric_values.add(code.numeric_value)
+            string_values.add(code.string_value)
 
         if self.documentation is not None:
             validators.validate_dict(self.documentation, "documentation")

--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -87,10 +87,11 @@ class CodeScheme(object):
 
         return ret
 
-    def _validate_code_values_unique(self, values, key_name):
+    def _validate_code_properties_unique(self, properties, property_name):
         seen = set()
-        for v in values:
-            assert v not in seen, f"Scheme {self.scheme_id} contains two codes with {key_name} {v}"
+        for p in properties:
+            assert p not in seen, f"Scheme {self.scheme_id} contains two codes with {property_name} {p}"
+            seen.add(p)
 
     def validate(self):
         validators.validate_string(self.scheme_id, "scheme_id")
@@ -102,17 +103,17 @@ class CodeScheme(object):
             assert isinstance(code, Code), f"self.codes[{i}] is not of type Code"
             code.validate()
 
-        self._validate_code_values_unique([c.code_id for c in self.codes], "code_id")
-        self._validate_code_values_unique([c.numeric_value for c in self.codes], "numeric_value")
-        self._validate_code_values_unique([c.string_value for c in self.codes], "string_value")
-        self._validate_code_values_unique([c.control_code for c in self.codes if c.code_type == CodeTypes.CONTROL], "control_code")
-        self._validate_code_values_unique([c.meta_code for c in self.codes if c.code_type == CodeTypes.META], "meta_code")
+        self._validate_code_properties_unique([c.code_id for c in self.codes], "code_id")
+        self._validate_code_properties_unique([c.numeric_value for c in self.codes], "numeric_value")
+        self._validate_code_properties_unique([c.string_value for c in self.codes], "string_value")
+        self._validate_code_properties_unique([c.control_code for c in self.codes if c.code_type == CodeTypes.CONTROL], "control_code")
+        self._validate_code_properties_unique([c.meta_code for c in self.codes if c.code_type == CodeTypes.META], "meta_code")
 
         match_values = []
         for code in self.codes:
             if code.match_values is not None:
                 match_values.extend(code.match_values)
-        self._validate_code_values_unique(match_values, "match value")
+        self._validate_code_properties_unique(match_values, "match value")
 
         if self.documentation is not None:
             validators.validate_dict(self.documentation, "documentation")

--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -104,13 +104,13 @@ class CodeScheme(object):
             seen.add(v)
 
     def validate(self):
-        validators.validate_string(self.scheme_id, "scheme_id")
-        validators.validate_string(self.name, "name")
-        validators.validate_string(self.version, "version")
+        validators.validate_string(self.scheme_id, f"CodeScheme id '{self.scheme_id}'")
+        validators.validate_string(self.name, f"'name' property of CodeScheme with id '{self.scheme_id}'")
+        validators.validate_string(self.version, f"'version' property of CodeScheme with id '{self.scheme_id}'")
 
-        validators.validate_list(self.codes, "codes")
+        validators.validate_list(self.codes, f"'codes' property of CodeScheme with id '{self.scheme_id}'")
         for i, code in enumerate(self.codes):
-            assert isinstance(code, Code), f"self.codes[{i}] is not of type Code"
+            assert isinstance(code, Code), f"'codes[{i}]' of CodeScheme with id '{self.scheme_id}' is not of type Code"
             code.validate()
 
         self._validate_code_values_unique([c.code_id for c in self.codes], "code_id")
@@ -126,8 +126,10 @@ class CodeScheme(object):
         self._validate_code_values_unique(match_values, "match value")
 
         if self.documentation is not None:
-            validators.validate_dict(self.documentation, "documentation")
-            validators.validate_string(self.documentation["URI"], "documentation[URI]")
+            validators.validate_dict(
+                self.documentation, f"'documentation' property of CodeScheme with id '{self.scheme_id}")
+            validators.validate_string(
+                self.documentation.get("URI"), f"'documentation[URI]' property of CodeScheme with id '{self.scheme_id}'")
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -87,28 +87,31 @@ class CodeScheme(object):
 
         return ret
 
+    def _validate_code_values_unique(self, values, key_name):
+        seen = set()
+        for v in values:
+            assert v not in seen, f"Scheme {self.scheme_id} contains two codes with {key_name} {v}"
+
     def validate(self):
         validators.validate_string(self.scheme_id, "scheme_id")
         validators.validate_string(self.name, "name")
         validators.validate_string(self.version, "version")
 
         validators.validate_list(self.codes, "codes")
-        code_ids = set()
-        numeric_values = set()
-        string_values = set()
         for i, code in enumerate(self.codes):
             assert isinstance(code, Code), f"self.codes[{i}] is not of type Code"
             code.validate()
 
-            assert code.code_id not in code_ids, \
-                f"Scheme {self.scheme_id} contains two codes with id {code.code_id}"
-            assert code.numeric_value not in numeric_values, \
-                f"Scheme {self.scheme_id} contains two codes with numeric value {code.numeric_value}"
-            assert code.string_value not in string_values, \
-                f"Scheme {self.scheme_id} contains two codes with string value {code.string_value}"
-            code_ids.add(code.code_id)
-            numeric_values.add(code.numeric_value)
-            string_values.add(code.string_value)
+        self._validate_code_values_unique([c.code_id for c in self.codes], "code_id")
+        self._validate_code_values_unique([c.numeric_value for c in self.codes], "numeric_value")
+        self._validate_code_values_unique([c.string_value for c in self.codes], "string_value")
+        self._validate_code_values_unique([c.control_code for c in self.codes if c.code_type == CodeTypes.CONTROL], "control_code")
+        self._validate_code_values_unique([c.meta_code for c in self.codes if c.code_type == CodeTypes.META], "meta_code")
+
+        match_values = []
+        for code in self.codes:
+            match_values.extend(code.match_values)
+        self._validate_code_values_unique(match_values, "match value")
 
         if self.documentation is not None:
             validators.validate_dict(self.documentation, "documentation")

--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -87,21 +87,21 @@ class CodeScheme(object):
 
         return ret
 
-    def _validate_code_properties_unique(self, properties, property_name):
+    def _validate_code_values_unique(self, values, property_name):
         """
-        Given a list of properties from this scheme's codes, asserts that each property is unique.
+        Given a list of values from this scheme's codes, asserts that each is unique.
         
-        Fails with an AssertionError if a duplicate property is found, otherwise passes through with no side-effects.
+        Fails with an AssertionError if a duplicate is found, otherwise passes through with no side-effects.
         
-        :param properties: Properties to check for duplicates.
-        :type properties: list of str
+        :param values: Values to check for duplicates.
+        :type values: list of str
         :param property_name: Name of the property being checked (for inclusion in the error message).
         :type property_name: str
         """
         seen = set()
-        for p in properties:
-            assert p not in seen, f"Scheme '{self.scheme_id}' contains two codes with {property_name} '{p}'"
-            seen.add(p)
+        for v in values:
+            assert v not in seen, f"Scheme with id '{self.scheme_id}' contains two codes with {property_name} '{v}'"
+            seen.add(v)
 
     def validate(self):
         validators.validate_string(self.scheme_id, "scheme_id")
@@ -113,17 +113,17 @@ class CodeScheme(object):
             assert isinstance(code, Code), f"self.codes[{i}] is not of type Code"
             code.validate()
 
-        self._validate_code_properties_unique([c.code_id for c in self.codes], "code_id")
-        self._validate_code_properties_unique([c.numeric_value for c in self.codes], "numeric_value")
-        self._validate_code_properties_unique([c.string_value for c in self.codes], "string_value")
-        self._validate_code_properties_unique([c.control_code for c in self.codes if c.code_type == CodeTypes.CONTROL], "control_code")
-        self._validate_code_properties_unique([c.meta_code for c in self.codes if c.code_type == CodeTypes.META], "meta_code")
+        self._validate_code_values_unique([c.code_id for c in self.codes], "code_id")
+        self._validate_code_values_unique([c.numeric_value for c in self.codes], "numeric_value")
+        self._validate_code_values_unique([c.string_value for c in self.codes], "string_value")
+        self._validate_code_values_unique([c.control_code for c in self.codes if c.code_type == CodeTypes.CONTROL], "control_code")
+        self._validate_code_values_unique([c.meta_code for c in self.codes if c.code_type == CodeTypes.META], "meta_code")
 
         match_values = []
         for code in self.codes:
             if code.match_values is not None:
                 match_values.extend(code.match_values)
-        self._validate_code_properties_unique(match_values, "match value")
+        self._validate_code_values_unique(match_values, "match value")
 
         if self.documentation is not None:
             validators.validate_dict(self.documentation, "documentation")

--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -88,9 +88,19 @@ class CodeScheme(object):
         return ret
 
     def _validate_code_properties_unique(self, properties, property_name):
+        """
+        Given a list of properties from this scheme's codes, asserts that each property is unique.
+        
+        Fails with an AssertionError if a duplicate property is found, otherwise passes through with no side-effects.
+        
+        :param properties: Properties to check for duplicates.
+        :type properties: list of str
+        :param property_name: Name of the property being checked (for inclusion in the error message).
+        :type property_name: str
+        """
         seen = set()
         for p in properties:
-            assert p not in seen, f"Scheme {self.scheme_id} contains two codes with {property_name} {p}"
+            assert p not in seen, f"Scheme '{self.scheme_id}' contains two codes with {property_name} '{p}'"
             seen.add(p)
 
     def validate(self):

--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -110,7 +110,8 @@ class CodeScheme(object):
 
         match_values = []
         for code in self.codes:
-            match_values.extend(code.match_values)
+            if code.match_values is not None:
+                match_values.extend(code.match_values)
         self._validate_code_values_unique(match_values, "match value")
 
         if self.documentation is not None:

--- a/core_data_modules/data_models/code_scheme.py
+++ b/core_data_modules/data_models/code_scheme.py
@@ -101,11 +101,11 @@ class CodeScheme(object):
             code.validate()
 
             assert code.code_id not in code_ids, \
-                f"Scheme contains two codes with id {code.code_id}"
+                f"Scheme {self.scheme_id} contains two codes with id {code.code_id}"
             assert code.numeric_value not in numeric_values, \
-                f"Scheme contains two codes with numeric value {code.numeric_value}"
+                f"Scheme {self.scheme_id} contains two codes with numeric value {code.numeric_value}"
             assert code.string_value not in string_values, \
-                f"Scheme contains two codes with string value {code.string_value}"
+                f"Scheme {self.scheme_id} contains two codes with string value {code.string_value}"
             code_ids.add(code.code_id)
             numeric_values.add(code.numeric_value)
             string_values.add(code.string_value)


### PR DESCRIPTION
Review #182 first.

This makes debugging invalid schemes easier, because you no longer need to search all your schemes for the problematic case. If this looks good, I'll update the validators for codes similarly.