### PR TITLE
Correct is not to ""

### DIFF
--- a/core_data_modules/util/io_utils.py
+++ b/core_data_modules/util/io_utils.py
@@ -24,5 +24,5 @@ class IOUtils(object):
         :type path: str
         """
         dir_path = os.path.dirname(path)
-        if dir_path is not "":
+        if dir_path != "":
             cls.ensure_dirs_exist(dir_path)


### PR DESCRIPTION
I don't think we were impacted by this because we were comparing interned strings, but it's slightly confusing and will generate a SyntaxWarning in Python 3.8.