### PR TITLE
Remove unused dependencies deprecation, six, and unicodecsv

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,6 @@ setup(
     url="https://github.com/AfricasVoices/CoreDataModules",
     packages=["core_data_modules"],
     setup_requires=["pytest-runner"],
-    install_requires=["deprecation", "six", "unicodecsv", "python-dateutil", "pytz"],
+    install_requires=["python-dateutil", "pytz"],
     tests_require=["pytest<=3.6.4"]
 )


### PR DESCRIPTION
These were needed back when we were supported both Python 2 + 3. Now that we've removed all support for Python 2, these can be cleaned up.