### PR TITLE
Add support for python 3.7 and 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
       - store_test_results:
           path: ~/test-results
 jobs:
-  python-3.6:
+  python-3-6:
     docker:
       - image: cimg/base:2020.01
     steps:
@@ -35,4 +35,4 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - python-3.6
+      - python-3-6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   python-3.6:
     docker:
-      - image: cimg/base
+      - image: cimg/base:2020.01
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   python-3.6:
     docker:
-      - image: docker:18.03.0-ce-git # Outer Container (environment in which the core data container will be built)
+      - image: cimg/base
     steps:
       - checkout
       - setup_remote_docker

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 commands:
   test-python:
     parameters:
@@ -24,7 +24,6 @@ commands:
           when: always
       - store_test_results:
           path: ~/test-results
-
 jobs:
   python-3.6:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,19 +25,19 @@ commands:
       - store_test_results:
           path: ~/test-results
 jobs:
-  python-3-6:
+  py-3-6:
     docker:
       - image: cimg/base:2020.01
     steps:
       - test-python:
           python-version: "3.6"
-  python-3-7:
+  py-3-7:
     docker:
       - image: cimg/base:2020.01
     steps:
       - test-python:
           python-version: "3.7"
-  python-3-8:
+  py-3-8:
     docker:
       - image: cimg/base:2020.01
     steps:
@@ -47,6 +47,6 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - python-3-6
-      - python-3-7
-      - python-3-8
+      - py-3-6
+      - py-3-7
+      - py-3-8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,15 @@
 version: 2
-jobs:
-  python-3.6:
-    docker:
-      - image: cimg/base:2020.01
+commands:
+  test-python:
+    parameters:
+      python-version:
+        type: string
     steps:
       - checkout
       - setup_remote_docker
       - run:
           name: Build Docker image
-          command: docker build -t core-data-modules --build-arg PYTHON_VERSION=3.6 .
+          command: docker build -t core-data-modules --build-arg PYTHON_VERSION=<<parameters.python-version>> .
       - run:
           name: Create Docker container # Inner Container (the core data container)
           command: docker container create --name core-data-container core-data-modules
@@ -23,6 +24,14 @@ jobs:
           when: always
       - store_test_results:
           path: ~/test-results
+
+jobs:
+  python-3.6:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - test-python:
+          python-version: "3.6"
 workflows:
   version: 2
   build-and-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,22 @@ jobs:
     steps:
       - test-python:
           python-version: "3.6"
+  python-3-7:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - test-python:
+          python-version: "3.7"
+  python-3-8:
+    docker:
+      - image: cimg/base:2020.01
+    steps:
+      - test-python:
+          python-version: "3.8"
 workflows:
   version: 2
   build-and-test:
     jobs:
       - python-3-6
+      - python-3-7
+      - python-3-8

--- a/tests/util/test_time_utils.py
+++ b/tests/util/test_time_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import timedelta
+from datetime import timedelta, datetime
 
 from dateutil.parser import isoparse
 
@@ -17,6 +17,8 @@ class TestTimeUtils(unittest.TestCase):
             TimeUtils.floor_timestamp_at_resolution(isoparse("2019-05-04T13:46:17.123456Z"), timedelta(hours=2)),
             isoparse("2019-05-04T12:00Z")
         )
+
+        datetime.fromisoformat("2019-05-04T12:00:00+03:00")
 
         with self.assertRaisesRegex(AssertionError, "Resolution (.*) longer than 1 day"):
             TimeUtils.floor_timestamp_at_resolution(isoparse("2000-01-01T12:00"), timedelta(days=3))

--- a/tests/util/test_time_utils.py
+++ b/tests/util/test_time_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 from dateutil.parser import isoparse
 
@@ -17,8 +17,6 @@ class TestTimeUtils(unittest.TestCase):
             TimeUtils.floor_timestamp_at_resolution(isoparse("2019-05-04T13:46:17.123456Z"), timedelta(hours=2)),
             isoparse("2019-05-04T12:00Z")
         )
-
-        datetime.fromisoformat("2019-05-04T12:00:00+03:00")
 
         with self.assertRaisesRegex(AssertionError, "Resolution (.*) longer than 1 day"):
             TimeUtils.floor_timestamp_at_resolution(isoparse("2000-01-01T12:00"), timedelta(days=3))


### PR DESCRIPTION
These are the next two versions of Python that have been out for more than a few months (the very latest stable release is 3.9.1).

To add support, we now run 3 independent test jobs for each of the minor versions, similar to how we used to test 3.6 and 2.7 when we supported those two versions. For brevity, the actual test steps have been extracted into a reusable command (for more on commands see https://circleci.com/docs/2.0/reusing-config/). I've verified with a test case that fails on 3.6 but not 3.7 - see commit 1876eeb below if you're interested in the details.

I've also updated the spec and build environment versions to latest, and updated the job names, so python-3.6 is now called py-3-6. The dot is removed for compatibility reasons with the latest spec, and 'python' is shortened to 'py' so that we can read the full job titles on github at a glance (with the full name, all the jobs unhelpfully display as python-3...).

(PS I've also tested USAID-IBTCI's pipelines against 3.7 + 3.8 and confirm they give the same outputs in both cases)