### PR TITLE
Add analysis_utils, engagement_counts, and theme_distributions to a new standardised analysis package

### DIFF
--- a/core_data_modules/analysis/__init__.py
+++ b/core_data_modules/analysis/__init__.py
@@ -1,0 +1,1 @@
+from .analysis_utils import AnalysisConfiguration

--- a/core_data_modules/analysis/analysis_utils.py
+++ b/core_data_modules/analysis/analysis_utils.py
@@ -1,3 +1,5 @@
+import csv
+
 from core_data_modules.cleaners import Codes
 from core_data_modules.data_models.code_scheme import CodeTypes
 
@@ -265,3 +267,11 @@ def filter_relevant(data, consent_withdrawn_key, analysis_configurations):
                 relevant_data.append(td)
                 break
     return relevant_data
+
+
+def write_csv(data, headers, f):
+    writer = csv.DictWriter(f, fieldnames=headers, lineterminator="\n")
+    writer.writeheader()
+
+    for row in data:
+        writer.writerow(row)

--- a/core_data_modules/analysis/analysis_utils.py
+++ b/core_data_modules/analysis/analysis_utils.py
@@ -178,7 +178,7 @@ def filter_opt_ins(data, consent_withdrawn_key, analysis_configurations):
     opt_ins = []
     for td in data:
         for config in analysis_configurations:
-            if opt_in(td, consent_withdrawn_key, analysis_configurations.coded_field, analysis_configurations.code_scheme):
+            if opt_in(td, consent_withdrawn_key, config.coded_field, config.code_scheme):
                 opt_ins.append(td)
                 break
     return opt_ins

--- a/core_data_modules/analysis/analysis_utils.py
+++ b/core_data_modules/analysis/analysis_utils.py
@@ -92,6 +92,9 @@ def labelled(td, consent_withdrawn_key, analysis_configuration):
     :return: Whether `td` contains a labelled response to `coding_plan` and did not withdraw consent.
     :rtype: bool
     """
+    if withdrew_consent(td, consent_withdrawn_key):
+        return False
+
     if not responded(td, analysis_configuration):
         return False
 

--- a/core_data_modules/analysis/analysis_utils.py
+++ b/core_data_modules/analysis/analysis_utils.py
@@ -1,0 +1,264 @@
+from core_data_modules.cleaners import Codes
+
+
+class AnalysisConfiguration(object):
+    def __init__(self, dataset_name, coded_field, code_scheme):
+        self.dataset_name = dataset_name,
+        self.coded_field = coded_field
+        self.code_scheme = code_scheme
+
+def _get_codes_from_td(td, coded_field, code_scheme):
+    if coded_field not in td:
+        return []
+
+    if type(td[coded_field]) == list:
+        labels = td[coded_field]
+    else:
+        labels = [td[coded_field]]
+
+    return [code_scheme.get_code_with_code_id(label["CodeID"]) for label in labels]
+
+
+def responded(td, coded_field, code_scheme):
+    codes = _get_codes_from_td(td, coded_field, code_scheme)
+    assert len(codes) >= 1
+    if len(codes) > 1:
+        # If there is an NA or NS code, there shouldn't be any other codes present.
+        for code in codes:
+            assert code.control_code != Codes.TRUE_MISSING and code.control_code != Codes.SKIPPED
+        return True
+    return codes[0].control_code != Codes.TRUE_MISSING and codes[0].control_code != Codes.SKIPPED
+
+
+def withdrew_consent(td, consent_withdrawn_key):
+    """
+    Returns whether the given TracedData object represents someone who withdrew their consent to have their data
+    analysed.
+
+    :param td: TracedData to check.
+    :type td: TracedData
+    :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+    :type consent_withdrawn_key: str
+    :return: Whether consent was withdrawn.
+    :rtype: bool
+    """
+    return td[consent_withdrawn_key] == Codes.TRUE
+
+
+def opt_in(td, consent_withdrawn_key, coded_field, code_scheme):
+    """
+    Returns whether the given TracedData object contains a response to the given coding_plan.
+
+    A response is any field that hasn't been labelled with either TRUE_MISSING or SKIPPED.
+    Returns False for participants who withdrew their consent to have their data analysed.
+
+    :param td: TracedData to check.
+    :type td: TracedData
+    :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+    :type consent_withdrawn_key: str
+    :param coding_plan: A coding plan specifying the field names to look up in `td`, and the code scheme to use
+                        to interpret those values.
+    :type coding_plan: src.lib.pipeline_configuration.CodingPlan
+    :return: Whether `td` contains a response to `coding_plan` and did not withdraw consent.
+    :rtype: bool
+    """
+    return not withdrew_consent(td, consent_withdrawn_key) and responded(td, coded_field, code_scheme)
+
+# @classmethod
+# def labelled(cls, td, consent_withdrawn_key, coded_field, code_scheme):
+#     """
+#     Returns whether the given TracedData object has been labelled under the given coding_plan.
+#
+#     An object is considered labelled if all of the following hold:
+#      - Consent was not withdrawn.
+#      - A response was received (see `AnalysisUtils.responded` for the definition of this).
+#      - The response has been assigned at least one label under each coding configuration.
+#      - None of the assigned labels have the control code NOT_REVIEWED.
+#
+#     :param td: TracedData to check.
+#     :type td: TracedData
+#     :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+#     :type consent_withdrawn_key: str
+#     :param coding_plan: A coding plan specifying the field names to look up in `td`, and the code scheme to use
+#                         to interpret those values.
+#     :type coding_plan: src.lib.pipeline_configuration.CodingPlan
+#     :return: Whether `td` contains a labelled response to `coding_plan` and did not withdraw consent.
+#     :rtype: bool
+#     """
+#     if cls.withdrew_consent(td, consent_withdrawn_key):
+#         return False
+#
+#     if not cls.responded(td, coded_field, code_scheme):
+#         return False
+#
+#     codes = cls._get_codes_from_td(td, coded_field, code_scheme)
+#     if len(codes) == 0:
+#         return False
+#     for code in codes:
+#         if code.control_code == Codes.NOT_REVIEWED:
+#             return False
+#
+#     return True
+#
+# @classmethod
+# def relevant(cls, td, consent_withdrawn_key, coding_plan):
+#     """
+#     Returns whether the given TracedData object contains a relevant response to the given coding_plan.
+#
+#     A response is considered relevant if it is labelled with a normal code under any of its coding configurations.
+#     Returns False for participants who withdrew their consent to have their data analysed.
+#
+#     :param td: TracedData to check.
+#     :type td: TracedData
+#     :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+#     :type consent_withdrawn_key: str
+#     :param coding_plan: A coding plan specifying the field names to look up in `td`, and the code scheme to use
+#                         to interpret those values.
+#     :type coding_plan: src.lib.pipeline_configuration.CodingPlan
+#     :return: Whether `td` contains a relevant response to `coding_plan`.
+#     :rtype: bool
+#     """
+#     if cls.withdrew_consent(td, consent_withdrawn_key):
+#         return False
+#
+#     if not cls.labelled(td, consent_withdrawn_key, coding_plan):
+#         return False
+#
+#     for cc in coding_plan.coding_configurations:
+#         if not cc.include_in_individuals_file:
+#             continue
+#
+#         codes = cls._get_td_codes_for_coding_configuration(td, cc)
+#         for code in codes:
+#             if code.code_type == CodeTypes.NORMAL:
+#                 return True
+#     return False
+#
+# @classmethod
+# def filter_responded(cls, data, coding_plans):
+#     """
+#     Filters a list of message or participant data for objects that responded to at least one of the given coding
+#     plans.
+#
+#     For the definition of "responded", see `AnalysisUtils.responded`
+#
+#     :param data: Message or participant data to filter.
+#     :type data: TracedData iterable
+#     :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+#     :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+#     :return: data, filtered for only the objects that responded to at least one of the coding plans.
+#     :rtype: list of TracedData
+#     """
+#     responded = []
+#     for td in data:
+#         for plan in coding_plans:
+#             if cls.responded(td, plan):
+#                 responded.append(td)
+#                 break
+#     return responded
+
+
+def filter_opt_ins(data, consent_withdrawn_key, analysis_configurations):
+    """
+    Filters a list of message or participant data for objects that opted-in and contained a response to at least
+    one of the given coding plans.
+
+    For the definition of "opted-in", see `AnalysisUtils.opt_in`
+
+    :param data: Message or participant data to filter.
+    :type data: TracedData iterable
+    :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+    :type consent_withdrawn_key: str
+    :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+    :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+    :return: data, filtered for only the objects that opted-in and responded to at least one of the coding plans.
+    :rtype: list of TracedData
+    """
+    opt_ins = []
+    for td in data:
+        for config in analysis_configurations:
+            if opt_in(td, consent_withdrawn_key, analysis_configurations.coded_field, analysis_configurations.code_scheme):
+                opt_ins.append(td)
+                break
+    return opt_ins
+
+
+# @classmethod
+# def filter_partially_labelled(cls, data, consent_withdrawn_key, coding_plans):
+#     """
+#     Filters a list of message or participant data for objects that opted-in and are fully labelled under at least
+#     one of the given coding plans.
+#
+#     For the definition of "labelled", see `AnalysisUtils.labelled`
+#
+#     :param data: Message or participant data to filter.
+#     :type data: TracedData iterable
+#     :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+#     :type consent_withdrawn_key: str
+#     :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+#     :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+#     :return: `data`, filtered for only the objects that opted-in and are labelled under at least one of the coding
+#              plans.
+#     :rtype: list of TracedData
+#     """
+#     labelled = []
+#     for td in data:
+#         for plan in coding_plans:
+#             if cls.labelled(td, consent_withdrawn_key, plan):
+#                 labelled.append(td)
+#                 break
+#     return labelled
+#
+# @classmethod
+# def filter_fully_labelled(cls, data, consent_withdrawn_key, coding_plans):
+#     """
+#     Filters a list of message or participant data for objects that opted-in and are fully labelled under all of
+#     the given coding plans.
+#
+#     For the definition of "labelled", see `AnalysisUtils.labelled`
+#
+#     :param data: Message or participant data to filter.
+#     :type data: TracedData iterable
+#     :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+#     :type consent_withdrawn_key: str
+#     :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+#     :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+#     :return: data, filtered for only the objects that opted-in and are labelled under all of the coding plans.
+#     :rtype: list of TracedData
+#     """
+#     labelled = []
+#     for td in data:
+#         td_is_labelled = True
+#         for plan in coding_plans:
+#             if not cls.labelled(td, consent_withdrawn_key, plan):
+#                 td_is_labelled = False
+#
+#         if td_is_labelled:
+#             labelled.append(td)
+#
+#     return labelled
+#
+# @classmethod
+# def filter_relevant(cls, data, consent_withdrawn_key, coding_plans):
+#     """
+#     Filters a list of message or participant data for objects that are relevant to at least one of the given coding
+#     plans.
+#
+#     For the definition of "relevant", see `AnalysisUtils.relevant`
+#
+#     :param data: Message or participant data to filter.
+#     :type data: TracedData iterable
+#     :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+#     :type consent_withdrawn_key: str
+#     :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+#     :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+#     :return: data, filtered for only the objects that are relevant to at least one of the coding plans.
+#     :rtype: list of TracedData
+#     """
+#     relevant = []
+#     for td in data:
+#         for plan in coding_plans:
+#             if cls.relevant(td, consent_withdrawn_key, plan):
+#                 relevant.append(td)
+#                 break
+#     return relevant

--- a/core_data_modules/analysis/analysis_utils.py
+++ b/core_data_modules/analysis/analysis_utils.py
@@ -209,57 +209,56 @@ def filter_opt_ins(data, consent_withdrawn_key, analysis_configurations):
 #                 labelled.append(td)
 #                 break
 #     return labelled
-#
-# @classmethod
-# def filter_fully_labelled(cls, data, consent_withdrawn_key, coding_plans):
-#     """
-#     Filters a list of message or participant data for objects that opted-in and are fully labelled under all of
-#     the given coding plans.
-#
-#     For the definition of "labelled", see `AnalysisUtils.labelled`
-#
-#     :param data: Message or participant data to filter.
-#     :type data: TracedData iterable
-#     :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
-#     :type consent_withdrawn_key: str
-#     :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
-#     :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
-#     :return: data, filtered for only the objects that opted-in and are labelled under all of the coding plans.
-#     :rtype: list of TracedData
-#     """
-#     labelled = []
-#     for td in data:
-#         td_is_labelled = True
-#         for plan in coding_plans:
-#             if not cls.labelled(td, consent_withdrawn_key, plan):
-#                 td_is_labelled = False
-#
-#         if td_is_labelled:
-#             labelled.append(td)
-#
-#     return labelled
-#
-# @classmethod
-# def filter_relevant(cls, data, consent_withdrawn_key, coding_plans):
-#     """
-#     Filters a list of message or participant data for objects that are relevant to at least one of the given coding
-#     plans.
-#
-#     For the definition of "relevant", see `AnalysisUtils.relevant`
-#
-#     :param data: Message or participant data to filter.
-#     :type data: TracedData iterable
-#     :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
-#     :type consent_withdrawn_key: str
-#     :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
-#     :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
-#     :return: data, filtered for only the objects that are relevant to at least one of the coding plans.
-#     :rtype: list of TracedData
-#     """
-#     relevant = []
-#     for td in data:
-#         for plan in coding_plans:
-#             if cls.relevant(td, consent_withdrawn_key, plan):
-#                 relevant.append(td)
-#                 break
-#     return relevant
+
+def filter_fully_labelled(data, consent_withdrawn_key, analysis_configurations):
+    """
+    Filters a list of message or participant data for objects that opted-in and are fully labelled under all of
+    the given coding plans.
+
+    For the definition of "labelled", see `AnalysisUtils.labelled`
+
+    :param data: Message or participant data to filter.
+    :type data: TracedData iterable
+    :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+    :type consent_withdrawn_key: str
+    :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+    :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+    :return: data, filtered for only the objects that opted-in and are labelled under all of the coding plans.
+    :rtype: list of TracedData
+    """
+    fully_labelled = []
+    for td in data:
+        td_is_labelled = True
+        for config in analysis_configurations:
+            if not labelled(td, consent_withdrawn_key, config):
+                td_is_labelled = False
+
+        if td_is_labelled:
+            fully_labelled.append(td)
+
+    return fully_labelled
+
+
+def filter_relevant(data, consent_withdrawn_key, analysis_configurations):
+    """
+    Filters a list of message or participant data for objects that are relevant to at least one of the given coding
+    plans.
+
+    For the definition of "relevant", see `AnalysisUtils.relevant`
+
+    :param data: Message or participant data to filter.
+    :type data: TracedData iterable
+    :param consent_withdrawn_key: Key in the TracedData of the consent withdrawn field.
+    :type consent_withdrawn_key: str
+    :param coding_plans: Coding plans specifying the fields in each TracedData object in `data` to look up.
+    :type coding_plans: list of src.lib.pipeline_configuration.CodingPlan
+    :return: data, filtered for only the objects that are relevant to at least one of the coding plans.
+    :rtype: list of TracedData
+    """
+    relevant_data = []
+    for td in data:
+        for config in analysis_configurations:
+            if relevant(td, consent_withdrawn_key, config):
+                relevant_data.append(td)
+                break
+    return relevant_data

--- a/core_data_modules/analysis/analysis_utils.py
+++ b/core_data_modules/analysis/analysis_utils.py
@@ -7,6 +7,7 @@ class AnalysisConfiguration(object):
         self.coded_field = coded_field
         self.code_scheme = code_scheme
 
+
 def _get_codes_from_td(td, coded_field, code_scheme):
     if coded_field not in td:
         return []

--- a/core_data_modules/analysis/engagement_analysis.py
+++ b/core_data_modules/analysis/engagement_analysis.py
@@ -1,0 +1,33 @@
+from collections import OrderedDict
+
+from core_data_modules.analysis import analysis_utils
+
+
+def engagement_counts(messages, individuals, consent_withdrawn_field, analysis_configurations):
+    engagement_counts = OrderedDict()  # of dataset name to counts
+
+    for config in analysis_configurations:
+        engagement_counts[config.dataset_name] = OrderedDict({
+            "Dataset": config.dataset_name,
+
+            "Total Messages": "-", # Can't report this for individual weeks because the data has been overwritten with "STOP"
+            "Total Messages with Opt-Ins": len(analysis_utils.filter_opt_ins(messages, consent_withdrawn_field, [config])),
+            # "Total Labelled Messages": len(analysis_utils.filter_fully_labelled(messages, consent_withdrawn_field, [config])),
+            # "Total Relevant Messages": len(analysis_utils.filter_relevant(messages, consent_withdrawn_field, [config])),
+
+            "Total Participants": "-",
+            "Total Participants with Opt-Ins": len(analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, [config]))
+            # "Total Relevant Participants": len(AnalysisUtils.filter_relevant(individuals, consent_withdrawn_field, [config]))
+        })
+
+    engagement_counts["Total"] = OrderedDict({
+        "Dataset": "Total",
+
+        "Total Messages": len(messages),
+        "Total Messages with Opt-Ins": len(analysis_utils.filter_opt_ins(messages, consent_withdrawn_field, analysis_configurations)),
+
+        "Total Participants": len(individuals),
+        "Total Participants with Opt-Ins": len(analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, analysis_configurations))
+    })
+
+    return engagement_counts

--- a/core_data_modules/analysis/engagement_analysis.py
+++ b/core_data_modules/analysis/engagement_analysis.py
@@ -2,6 +2,12 @@ from collections import OrderedDict
 
 from core_data_modules.analysis import analysis_utils
 
+engagement_counts_headers = [
+    "Dataset",
+    "Total Messages", "Total Messages with Opt-Ins",
+    "Total Participants", "Total Participants with Opt-Ins"
+]
+
 
 def engagement_counts(messages, individuals, consent_withdrawn_field, analysis_configurations):
     engagement_counts = OrderedDict()  # of dataset name to counts

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -49,7 +49,7 @@ def compute_engagement_counts(messages, individuals, consent_withdrawn_field, an
 
         "Total Messages": len(messages),
         "Total Messages with Opt-Ins": len(analysis_utils.filter_opt_ins(messages, consent_withdrawn_field, analysis_configurations)),
-        "Total Labelled Messages": len(analysis_utils.filter_fully_labelled(messages, consent_withdrawn_field, analysis_configurations)),
+        "Total Labelled Messages": len(analysis_utils.filter_partially_labelled(messages, consent_withdrawn_field, analysis_configurations)),
         "Total Relevant Messages": len(analysis_utils.filter_relevant(messages, consent_withdrawn_field, analysis_configurations)),
 
         "Total Participants": len(individuals),

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -4,7 +4,7 @@ from core_data_modules.analysis import analysis_utils
 
 engagement_counts_headers = [
     "Dataset",
-    "Total Messages", "Total Messages with Opt-Ins",
+    "Total Messages", "Total Messages with Opt-Ins", "Total Labelled Messages", "Total Relevant Messages",
     "Total Participants", "Total Participants with Opt-Ins"
 ]
 

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -60,7 +60,7 @@ def compute_engagement_counts(messages, individuals, consent_withdrawn_field, an
     return engagement_counts
 
 
-def write_engagement_counts_csv(messages, individuals, consent_withdrawn_field, analysis_configurations, f):
+def export_engagement_counts_csv(messages, individuals, consent_withdrawn_field, analysis_configurations, f):
     """
     Computes the engagement_counts and exports them to a CSV.
 

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -10,7 +10,7 @@ engagement_counts_headers = [
 
 
 def compute_engagement_counts(messages, individuals, consent_withdrawn_field, analysis_configurations):
-    engagement_counts = OrderedDict()  # of dataset name to counts
+    engagement_counts = OrderedDict()  # of dataset name to an engagement counts dict, with keys `engagement_counts_headers`
 
     for config in analysis_configurations:
         engagement_counts[config.dataset_name] = OrderedDict({

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -18,8 +18,8 @@ def compute_engagement_counts(messages, individuals, consent_withdrawn_field, an
 
             "Total Messages": "-", # Can't report this for individual weeks because the data has been overwritten with "STOP"
             "Total Messages with Opt-Ins": len(analysis_utils.filter_opt_ins(messages, consent_withdrawn_field, [config])),
-            # "Total Labelled Messages": len(analysis_utils.filter_fully_labelled(messages, consent_withdrawn_field, [config])),
-            # "Total Relevant Messages": len(analysis_utils.filter_relevant(messages, consent_withdrawn_field, [config])),
+            "Total Labelled Messages": len(analysis_utils.filter_fully_labelled(messages, consent_withdrawn_field, [config])),
+            "Total Relevant Messages": len(analysis_utils.filter_relevant(messages, consent_withdrawn_field, [config])),
 
             "Total Participants": "-",
             "Total Participants with Opt-Ins": len(analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, [config]))
@@ -31,6 +31,8 @@ def compute_engagement_counts(messages, individuals, consent_withdrawn_field, an
 
         "Total Messages": len(messages),
         "Total Messages with Opt-Ins": len(analysis_utils.filter_opt_ins(messages, consent_withdrawn_field, analysis_configurations)),
+        "Total Labelled Messages": len(analysis_utils.filter_fully_labelled(messages, consent_withdrawn_field, analysis_configurations)),
+        "Total Relevant Messages": len(analysis_utils.filter_relevant(messages, consent_withdrawn_field, analysis_configurations)),
 
         "Total Participants": len(individuals),
         "Total Participants with Opt-Ins": len(analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, analysis_configurations))

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -5,7 +5,7 @@ from core_data_modules.analysis import analysis_utils
 engagement_counts_headers = [
     "Dataset",
     "Total Messages", "Total Messages with Opt-Ins", "Total Labelled Messages", "Total Relevant Messages",
-    "Total Participants", "Total Participants with Opt-Ins"
+    "Total Participants", "Total Participants with Opt-Ins", "Total Relevant Participants"
 ]
 
 
@@ -22,8 +22,8 @@ def compute_engagement_counts(messages, individuals, consent_withdrawn_field, an
             "Total Relevant Messages": len(analysis_utils.filter_relevant(messages, consent_withdrawn_field, [config])),
 
             "Total Participants": "-",
-            "Total Participants with Opt-Ins": len(analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, [config]))
-            # "Total Relevant Participants": len(AnalysisUtils.filter_relevant(individuals, consent_withdrawn_field, [config]))
+            "Total Participants with Opt-Ins": len(analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, [config])),
+            "Total Relevant Participants": len(analysis_utils.filter_relevant(individuals, consent_withdrawn_field, [config]))
         })
 
     engagement_counts["Total"] = OrderedDict({
@@ -35,7 +35,8 @@ def compute_engagement_counts(messages, individuals, consent_withdrawn_field, an
         "Total Relevant Messages": len(analysis_utils.filter_relevant(messages, consent_withdrawn_field, analysis_configurations)),
 
         "Total Participants": len(individuals),
-        "Total Participants with Opt-Ins": len(analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, analysis_configurations))
+        "Total Participants with Opt-Ins": len(analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, analysis_configurations)),
+        "Total Relevant Participants": len(analysis_utils.filter_relevant(individuals, consent_withdrawn_field, analysis_configurations))
     })
 
     return engagement_counts

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -40,3 +40,11 @@ def compute_engagement_counts(messages, individuals, consent_withdrawn_field, an
     })
 
     return engagement_counts
+
+
+def write_engagement_counts_csv(messages, individuals, consent_withdrawn_field, analysis_configurations, f):
+    analysis_utils.write_csv(
+        compute_engagement_counts(messages, individuals, consent_withdrawn_field, analysis_configurations).values(),
+        engagement_counts_headers,
+        f
+    )

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -9,7 +9,7 @@ engagement_counts_headers = [
 ]
 
 
-def engagement_counts(messages, individuals, consent_withdrawn_field, analysis_configurations):
+def compute_engagement_counts(messages, individuals, consent_withdrawn_field, analysis_configurations):
     engagement_counts = OrderedDict()  # of dataset name to counts
 
     for config in analysis_configurations:

--- a/core_data_modules/analysis/engagement_counts.py
+++ b/core_data_modules/analysis/engagement_counts.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from core_data_modules.analysis import analysis_utils
 
-engagement_counts_headers = [
+engagement_counts_keys = [
     "Dataset",
     "Total Messages", "Total Messages with Opt-Ins", "Total Labelled Messages", "Total Relevant Messages",
     "Total Participants", "Total Participants with Opt-Ins", "Total Relevant Participants"
@@ -10,7 +10,25 @@ engagement_counts_headers = [
 
 
 def compute_engagement_counts(messages, individuals, consent_withdrawn_field, analysis_configurations):
-    engagement_counts = OrderedDict()  # of dataset name to an engagement counts dict, with keys `engagement_counts_headers`
+    """
+    Computes the engagement counts for a list of messages and individuals.
+
+    Returns a dictionary of dataset_name | "Total" -> dict with keys `engagement_counts_keys`.
+    For definitions of each of the terms used here ("Opt-Ins", "Labelled", etc.), see the relevant function in
+    `core_data_modules.analysis.analysis_utils`.
+
+    :param messages: Messages to compute the engagement_counts for.
+    :type messages: iterable of core_data_modules.traced_data.TracedData
+    :param individuals: Individuals to compute the engagement_counts for.
+    :type individuals: iterable of core_data_modules.traced_data.TracedData
+    :param consent_withdrawn_field: Field in each messages/individuals object which records if consent is withdrawn.
+    :type consent_withdrawn_field: str
+    :param analysis_configurations: Configurations for the datasets/coded fields to include in the engagement_counts.
+    :type analysis_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :return: Dictionary of dataset_name | "Total" -> dict with keys `engagement_counts_keys`.
+    :rtype: OrderedDict of str -> dict
+    """
+    engagement_counts = OrderedDict()  # of dataset_name -> dict with keys `engagement_counts_keys`
 
     for config in analysis_configurations:
         engagement_counts[config.dataset_name] = OrderedDict({
@@ -43,8 +61,24 @@ def compute_engagement_counts(messages, individuals, consent_withdrawn_field, an
 
 
 def write_engagement_counts_csv(messages, individuals, consent_withdrawn_field, analysis_configurations, f):
+    """
+    Computes the engagement_counts and exports them to a CSV.
+
+    :param messages: Messages to compute the engagement_counts for.
+    :type messages: iterable of core_data_modules.traced_data.TracedData
+    :param individuals: Individuals to compute the engagement_counts for.
+    :type individuals: iterable of core_data_modules.traced_data.TracedData
+    :param consent_withdrawn_field: Field in each messages/individuals object which records if consent is withdrawn.
+    :type consent_withdrawn_field: str
+    :param analysis_configurations: Configurations for the datasets/coded fields to include in the engagement_counts.
+    :type analysis_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :return: Dictionary of dataset_name | "Total" -> dict with keys `engagement_counts_keys`.
+    :rtype: OrderedDict of str -> dict
+    :param f: File to write the engagement_counts CSV to.
+    :type f: file-like
+    """
     analysis_utils.write_csv(
         compute_engagement_counts(messages, individuals, consent_withdrawn_field, analysis_configurations).values(),
-        engagement_counts_headers,
+        engagement_counts_keys,
         f
     )

--- a/core_data_modules/analysis/theme_distributions.py
+++ b/core_data_modules/analysis/theme_distributions.py
@@ -1,0 +1,66 @@
+from collections import OrderedDict
+
+from core_data_modules.analysis import analysis_utils
+from core_data_modules.cleaners import Codes
+
+
+def _non_stop_codes(codes):
+    return [code for code in codes if code.control_code != Codes.STOP]
+
+
+def _make_survey_counts_dict(survey_configurations):
+    survey_counts = OrderedDict()
+
+    survey_counts["Total Participants"] = 0
+    survey_counts["Total Participants %"] = None
+
+    for config in survey_configurations:
+        for code in _non_stop_codes(config.code_scheme.codes):
+            survey_counts[f"{config.dataset_name}:{code.string_value}"] = 0
+            survey_counts[f"{config.dataset_name}:{code.string_value} %"] = None
+
+    return survey_counts
+
+
+def _update_survey_counts_dict(survey_counts, individual, survey_configurations):
+    for config in survey_configurations:
+        for code in _non_stop_codes(analysis_utils.get_codes_from_td(individual, config)):
+            survey_counts[f"{config.dataset_name}:{code.string_value}"] += 1
+
+
+def _set_survey_counts_percentages(survey_counts, total_survey_counts, survey_configurations):
+    pass
+
+
+def compute_theme_distributions(individuals, consent_withdrawn_field, theme_configurations, survey_configurations):
+    theme_distributions = OrderedDict()  # of TODO
+
+    individuals = analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, theme_configurations)
+
+    # For each theme configuration, create a dict of theme dataset_name -> (dict of survey code -> count/%)
+    for theme_config in theme_configurations:
+        themes = OrderedDict()
+        theme_distributions[theme_config.dataset_name] = themes
+
+        # For each code in the rqa code scheme, add an entry
+        for code in _non_stop_codes(theme_config.code_scheme.codes):
+            themes["Total Relevant Participants"] = 0
+            themes[f"{theme_config.dataset_name}_{code.string_value}"] = _make_survey_counts_dict(survey_configurations)
+
+        for ind in individuals:
+            # If the individual is relevant to this rqa configuration, increase the total relevant count and
+            # associated survey columns by 1.
+            if analysis_utils.relevant(ind, consent_withdrawn_field, theme_config):
+                themes["Total Relevant Participants"]["Total Participants"] += 1
+                _update_survey_counts_dict(themes["Total Relevant Participants"], ind, survey_configurations)
+
+            # For each theme in this rqa configuration, increase the theme's total count and associated survey columns
+            # by 1.
+            for code in analysis_utils.get_codes_from_td(ind, theme_config):
+                theme_name = f"{theme_config.dataset_name}_{code.string_value}"
+                themes[theme_name] += 1
+                _update_survey_counts_dict(themes[theme_name], ind, survey_configurations)
+
+    # TODO: Set percentages
+
+    return theme_distributions

--- a/core_data_modules/analysis/theme_distributions.py
+++ b/core_data_modules/analysis/theme_distributions.py
@@ -13,26 +13,26 @@ def _normal_codes(codes):
     return [code for code in codes if code.code_type == CodeTypes.NORMAL]
 
 
-def _make_survey_counts_dict(survey_configurations):
-    survey_counts = OrderedDict()
+def _make_breakdowns_dict(breakdown_configurations):
+    breakdowns = OrderedDict()
 
-    survey_counts["Total Participants"] = 0
-    survey_counts["Total Participants %"] = None
+    breakdowns["Total Participants"] = 0
+    breakdowns["Total Participants %"] = None
 
-    for config in survey_configurations:
+    for config in breakdown_configurations:
         for code in _non_stop_codes(config.code_scheme.codes):
-            survey_counts[f"{config.dataset_name}:{code.string_value}"] = 0
-            survey_counts[f"{config.dataset_name}:{code.string_value} %"] = None
+            breakdowns[f"{config.dataset_name}:{code.string_value}"] = 0
+            breakdowns[f"{config.dataset_name}:{code.string_value} %"] = None
 
-    return survey_counts
+    return breakdowns
 
 
-def _update_survey_counts_dict(survey_counts, individual, survey_configurations):
-    survey_counts["Total Participants"] += 1
+def _update_breakdowns(breakdowns, individual, breakdown_configurations):
+    breakdowns["Total Participants"] += 1
 
-    for config in survey_configurations:
+    for config in breakdown_configurations:
         for code in _non_stop_codes(analysis_utils.get_codes_from_td(individual, config)):
-            survey_counts[f"{config.dataset_name}:{code.string_value}"] += 1
+            breakdowns[f"{config.dataset_name}:{code.string_value}"] += 1
 
 
 def _compute_percentage_str(x, y):
@@ -42,80 +42,79 @@ def _compute_percentage_str(x, y):
         return str(round(x / y * 100, 1))
 
 
-def _set_survey_counts_percentages(survey_counts, total_survey_counts, survey_configurations):
-    survey_counts["Total Participants %"] = \
-        _compute_percentage_str(survey_counts["Total Participants"], total_survey_counts["Total Participants"])
+def _compute_breakdown_percentages(breakdowns, total_breakdowns, breakdown_configurations):
+    breakdowns["Total Participants %"] = \
+        _compute_percentage_str(breakdowns["Total Participants"], total_breakdowns["Total Participants"])
 
-    for config in survey_configurations:
+    for config in breakdown_configurations:
         for code in _non_stop_codes(config.code_scheme.codes):
             theme_name = f"{config.dataset_name}:{code.string_value}"
-            survey_counts[f"{theme_name} %"] = \
-                _compute_percentage_str(survey_counts[theme_name], total_survey_counts[theme_name])
+            breakdowns[f"{theme_name} %"] = \
+                _compute_percentage_str(breakdowns[theme_name], total_breakdowns[theme_name])
 
 
-def _compute_theme_distributions_for_rqa(individuals, consent_withdrawn_field, theme_config, survey_configurations):
-    themes = OrderedDict()  # of rqa code -> (dict of survey_code -> dict of count/%)
+def _compute_theme_distributions_for_dataset(individuals, consent_withdrawn_field, theme_config, breakdown_configurations):
+    themes = OrderedDict()  # of theme_config dataset name -> theme -> (dict of breakdown code -> dict of count/%)
 
-    # For each code in the rqa code scheme, add an entry
-    themes["Total Relevant Participants"] = _make_survey_counts_dict(survey_configurations)
+    themes["Total Relevant Participants"] = _make_breakdowns_dict(breakdown_configurations)
     for code in _non_stop_codes(theme_config.code_scheme.codes):
-        themes[f"{theme_config.dataset_name}_{code.string_value}"] = _make_survey_counts_dict(survey_configurations)
+        themes[f"{theme_config.dataset_name}_{code.string_value}"] = _make_breakdowns_dict(breakdown_configurations)
 
     # Iterate over the individuals, increasing the counts as needed
     for ind in individuals:
         if analysis_utils.relevant(ind, consent_withdrawn_field, theme_config):
-            _update_survey_counts_dict(themes["Total Relevant Participants"], ind, survey_configurations)
+            _update_breakdowns(themes["Total Relevant Participants"], ind, breakdown_configurations)
 
         for code in analysis_utils.get_codes_from_td(ind, theme_config):
-            _update_survey_counts_dict(themes[f"{theme_config.dataset_name}_{code.string_value}"],
-                                       ind, survey_configurations)
+            _update_breakdowns(themes[f"{theme_config.dataset_name}_{code.string_value}"],
+                               ind, breakdown_configurations)
 
-    _set_survey_counts_percentages(
+    _compute_breakdown_percentages(
         themes["Total Relevant Participants"], themes["Total Relevant Participants"],
-        survey_configurations
+        breakdown_configurations
     )
 
     for code in _normal_codes(theme_config.code_scheme.codes):
-        _set_survey_counts_percentages(
+        _compute_breakdown_percentages(
             themes[f"{theme_config.dataset_name}_{code.string_value}"], themes["Total Relevant Participants"],
-            survey_configurations
+            breakdown_configurations
         )
 
     return themes
 
 
-def compute_theme_distributions(individuals, consent_withdrawn_field, theme_configurations, survey_configurations):
+def compute_theme_distributions(individuals, consent_withdrawn_field, theme_configurations, breakdown_configurations):
     theme_distributions = OrderedDict()  # of dataset_name -> theme ->
 
     individuals = analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, theme_configurations)
 
-    # For each theme configuration, create a dict of theme dataset_name -> (dict of survey code -> count/%)
+    # For each theme configuration, create a dict of theme dataset_name -> (dict of breakdown code -> count/%)
     for theme_config in theme_configurations:
-        theme_distributions[theme_config.dataset_name] = _compute_theme_distributions_for_rqa(
-            individuals, consent_withdrawn_field, theme_config, survey_configurations
+        theme_distributions[theme_config.dataset_name] = _compute_theme_distributions_for_dataset(
+            individuals, consent_withdrawn_field, theme_config, breakdown_configurations
         )
 
     return theme_distributions
 
 
-def write_theme_distributions_csv(individuals, consent_withdrawn_field, theme_configurations, survey_configurations, f):
+def write_theme_distributions_csv(individuals, consent_withdrawn_field, theme_configurations, breakdown_configurations, f):
     theme_distributions = compute_theme_distributions(individuals, consent_withdrawn_field,
-                                                      theme_configurations, survey_configurations)
+                                                      theme_configurations, breakdown_configurations)
 
     csv_data = []
     last_dataset_name = None
     for dataset_name, themes in theme_distributions.items():
-        for theme, survey_counts in themes.items():
+        for theme, breakdowns in themes.items():
             row = {
                 "Theme": theme,
                 "Dataset": dataset_name if dataset_name != last_dataset_name else ""
             }
-            row.update(survey_counts)
+            row.update(breakdowns)
             csv_data.append(row)
             last_dataset_name = dataset_name
 
     headers = ["Dataset", "Theme"]
-    headers.extend(_make_survey_counts_dict(survey_configurations).keys())
+    headers.extend(_make_breakdowns_dict(breakdown_configurations).keys())
 
     analysis_utils.write_csv(
         csv_data,

--- a/core_data_modules/analysis/theme_distributions.py
+++ b/core_data_modules/analysis/theme_distributions.py
@@ -2,10 +2,15 @@ from collections import OrderedDict
 
 from core_data_modules.analysis import analysis_utils
 from core_data_modules.cleaners import Codes
+from core_data_modules.data_models.code_scheme import CodeTypes
 
 
 def _non_stop_codes(codes):
     return [code for code in codes if code.control_code != Codes.STOP]
+
+
+def _normal_codes(codes):
+    return [code for code in codes if code.code_type == CodeTypes.NORMAL]
 
 
 def _make_survey_counts_dict(survey_configurations):
@@ -23,13 +28,29 @@ def _make_survey_counts_dict(survey_configurations):
 
 
 def _update_survey_counts_dict(survey_counts, individual, survey_configurations):
+    survey_counts["Total Participants"] += 1
+
     for config in survey_configurations:
         for code in _non_stop_codes(analysis_utils.get_codes_from_td(individual, config)):
             survey_counts[f"{config.dataset_name}:{code.string_value}"] += 1
 
 
+def _compute_percentage_str(x, y):
+    if y == 0:
+        return "-"
+    else:
+        return str(round(x / y * 100, 1))
+
+
 def _set_survey_counts_percentages(survey_counts, total_survey_counts, survey_configurations):
-    pass
+    survey_counts["Total Participants %"] = \
+        _compute_percentage_str(survey_counts["Total Participants"], total_survey_counts["Total Participants"])
+
+    for config in survey_configurations:
+        for code in _non_stop_codes(config.code_scheme.codes):
+            theme_name = f"{config.dataset_name}:{code.string_value}"
+            survey_counts[f"{theme_name} %"] = \
+                _compute_percentage_str(survey_counts[theme_name], total_survey_counts[theme_name])
 
 
 def compute_theme_distributions(individuals, consent_withdrawn_field, theme_configurations, survey_configurations):
@@ -39,28 +60,58 @@ def compute_theme_distributions(individuals, consent_withdrawn_field, theme_conf
 
     # For each theme configuration, create a dict of theme dataset_name -> (dict of survey code -> count/%)
     for theme_config in theme_configurations:
-        themes = OrderedDict()
+        themes = OrderedDict()  # of survey_code -> count/%
         theme_distributions[theme_config.dataset_name] = themes
 
         # For each code in the rqa code scheme, add an entry
+        themes["Total Relevant Participants"] = _make_survey_counts_dict(survey_configurations)
         for code in _non_stop_codes(theme_config.code_scheme.codes):
-            themes["Total Relevant Participants"] = 0
             themes[f"{theme_config.dataset_name}_{code.string_value}"] = _make_survey_counts_dict(survey_configurations)
 
+        # Iterate over the individuals, increasing the counts as needed
         for ind in individuals:
-            # If the individual is relevant to this rqa configuration, increase the total relevant count and
-            # associated survey columns by 1.
             if analysis_utils.relevant(ind, consent_withdrawn_field, theme_config):
-                themes["Total Relevant Participants"]["Total Participants"] += 1
                 _update_survey_counts_dict(themes["Total Relevant Participants"], ind, survey_configurations)
 
-            # For each theme in this rqa configuration, increase the theme's total count and associated survey columns
-            # by 1.
             for code in analysis_utils.get_codes_from_td(ind, theme_config):
-                theme_name = f"{theme_config.dataset_name}_{code.string_value}"
-                themes[theme_name] += 1
-                _update_survey_counts_dict(themes[theme_name], ind, survey_configurations)
+                _update_survey_counts_dict(themes[f"{theme_config.dataset_name}_{code.string_value}"],
+                                           ind, survey_configurations)
 
-    # TODO: Set percentages
+        _set_survey_counts_percentages(
+            themes["Total Relevant Participants"], themes["Total Relevant Participants"],
+            survey_configurations
+        )
+
+        for code in _normal_codes(theme_config.code_scheme.codes):
+            _set_survey_counts_percentages(
+                themes[f"{theme_config.dataset_name}_{code.string_value}"],  themes["Total Relevant Participants"],
+                survey_configurations
+            )
 
     return theme_distributions
+
+
+def write_theme_distributions_csv(individuals, consent_withdrawn_field, theme_configurations, survey_configurations, f):
+    theme_distributions = compute_theme_distributions(individuals, consent_withdrawn_field,
+                                                      theme_configurations, survey_configurations)
+
+    csv_data = []
+    last_dataset_name = None
+    for dataset_name, themes in theme_distributions.items():
+        for theme, survey_counts in themes.items():
+            row = {
+                "Theme": theme,
+                "Dataset": dataset_name if dataset_name != last_dataset_name else ""
+            }
+            row.update(survey_counts)
+            csv_data.append(row)
+            last_dataset_name = dataset_name
+
+    headers = ["Dataset", "Theme"]
+    headers.extend(_make_survey_counts_dict(survey_configurations).keys())
+
+    analysis_utils.write_csv(
+        csv_data,
+        headers,
+        f
+    )

--- a/core_data_modules/analysis/theme_distributions.py
+++ b/core_data_modules/analysis/theme_distributions.py
@@ -217,10 +217,10 @@ def compute_theme_distributions(individuals, consent_withdrawn_field, theme_conf
     return theme_distributions
 
 
-def write_theme_distributions_csv(individuals, consent_withdrawn_field,
-                                  theme_configurations, breakdown_configurations, f):
+def export_theme_distributions_csv(individuals, consent_withdrawn_field,
+                                   theme_configurations, breakdown_configurations, f):
     """
-    Computes the theme_distributions and writes them to a CSV.
+    Computes the theme_distributions and exports them to a CSV.
 
     The CSV will contain the headers:
      - Dataset, set to the dataset_name in each of the `theme_configurations`, de-duplicated for clarity).

--- a/core_data_modules/analysis/theme_distributions.py
+++ b/core_data_modules/analysis/theme_distributions.py
@@ -6,14 +6,46 @@ from core_data_modules.data_models.code_scheme import CodeTypes
 
 
 def _non_stop_codes(codes):
+    """
+    Filters a list of codes for those that do not have control code Codes.STOP.
+
+    :param codes: Codes to filter.
+    :type codes: list of core_data_modules.data_models.Code
+    :return: All codes in `codes` except those with control code Codes.STOP.
+    :rtype: list of core_data_modules.data_models.Code
+    """
     return [code for code in codes if code.control_code != Codes.STOP]
 
 
 def _normal_codes(codes):
+    """
+    Filters a list of codes for those with code type CodeTypes.NORMAL.
+
+    :param codes: Codes to filter.
+    :type codes: list of core_data_modules.data_models.Code
+    :return: All codes in `codes` which have code type CodeTypes.NORMAL.
+    :rtype: list of core_data_modules.data_models.Code
+    """
     return [code for code in codes if code.code_type == CodeTypes.NORMAL]
 
 
 def _make_breakdowns_dict(breakdown_configurations):
+    """
+    Constructs a dictionary to store breakdown counts and percentages for the given breakdown_configurations.
+
+    The returned dictionary will contain the following:
+     - "Total Participants": 0
+     - "Total Participants %": None (to set this later see `theme_distributions._compute_breakdown_percentages`.
+     - For each code in each breakdown_configuration:
+       - "{breakdown_configuration.dataset_name}:{code.string_value}": 0
+       - "{breakdown_configuration.dataset_name}:{code.string_value} %": None
+       For example, "age:20": 0, "age:20 %": None
+
+    :param breakdown_configurations: Configuration for the breakdowns.
+    :type breakdown_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :return: Initialised breakdowns dictionary.
+    :rtype: dict of str -> (int | None)
+    """
     breakdowns = OrderedDict()
 
     breakdowns["Total Participants"] = 0
@@ -27,7 +59,24 @@ def _make_breakdowns_dict(breakdown_configurations):
     return breakdowns
 
 
-def _update_breakdowns(breakdowns, individual, breakdown_configurations):
+def _increment_breakdowns(breakdowns, individual, breakdown_configurations):
+    """
+    Increments the non-percentage entries of a breakdowns dictionary in-place based on the codes present in the given
+    individual.
+
+    The "Total Participants" entry in `breakdowns` will always be incremented by 1.
+    The remaining entries will be incremented by 1 if the code is present in the `individual`.
+
+    For efficiency reasons, the percentage fields are not touched so may go out of sync without a subsequent call to
+    _compute_breakdown_percentages.
+
+    :param breakdowns: Breakdowns dictionary to update.
+    :type breakdowns: dict of str -> (int | str | None)
+    :param individual: Individual to use to update the breakdowns dictionary.
+    :type individual: core_data_modules.traced_data.TracedData
+    :param breakdown_configurations: Configuration for the breakdowns.
+    :type breakdown_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    """
     breakdowns["Total Participants"] += 1
 
     for config in breakdown_configurations:
@@ -36,6 +85,18 @@ def _update_breakdowns(breakdowns, individual, breakdown_configurations):
 
 
 def _compute_percentage_str(x, y):
+    """
+    Formats x as a percentage of y as a string to 1 decimal place.
+
+    If y is 0, returns "-".
+
+    :param x: Dividend.
+    :type x: number
+    :param y: Divisor.
+    :type y: number
+    :return: "-" if y == 0, otherwise x / y to 1 decimal place.
+    :rtype: str
+    """
     if y == 0:
         return "-"
     else:
@@ -43,6 +104,16 @@ def _compute_percentage_str(x, y):
 
 
 def _compute_breakdown_percentages(breakdowns, total_breakdowns, breakdown_configurations):
+    """
+    Sets the percentage fields in a breakdowns dict, in-place.
+
+    :param breakdowns: Breakdowns dictionary to update.
+    :type breakdowns: dict of str -> (str | int | None)
+    :param total_breakdowns: Breakdowns dictionary containing the totals to compute the percentages out of.
+    :type total_breakdowns: dict of str -> (str | int | None)
+    :param breakdown_configurations: Configuration for the breakdowns.
+    :type breakdown_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    """
     breakdowns["Total Participants %"] = \
         _compute_percentage_str(breakdowns["Total Participants"], total_breakdowns["Total Participants"])
 
@@ -53,30 +124,58 @@ def _compute_breakdown_percentages(breakdowns, total_breakdowns, breakdown_confi
                 _compute_percentage_str(breakdowns[theme_name], total_breakdowns[theme_name])
 
 
-def _compute_theme_distributions_for_dataset(individuals, consent_withdrawn_field, theme_config, breakdown_configurations):
-    themes = OrderedDict()  # of theme_config dataset name -> theme -> (dict of breakdown code -> dict of count/%)
+def _compute_theme_distributions_for_theme_configuration(individuals, consent_withdrawn_field, theme_configuration,
+                                                         breakdown_configurations):
+    """
+    Computes the theme_distributions for a list of individuals, for a single theme_configuration.
 
+    Returns a dictionary of theme -> breakdowns.
+
+    :param individuals: Individuals to compute the theme_distributions for.
+    :type individuals: iterable of core_data_modules.traced_data.TracedData
+    :param consent_withdrawn_field: Field in each individuals object which records if consent is withdrawn.
+    :type consent_withdrawn_field: str
+    :param theme_configuration: Configuration for the themes. Each configuration should contain:
+                                - dataset_name.
+                                - code_scheme. This will be used to index the returned dict (the "theme" above).
+                                  Themes are formatted as
+                                  {theme_configuration.dataset_name}_{code.string_value} for each code in the
+                                  code_scheme.
+    :type theme_configuration: core_data_modules.analysis.AnalysisConfiguration
+    :param breakdown_configurations: Configuration for the breakdowns dict.
+                                     For details, see `theme_distributions._make_breakdowns_dict`.
+    :type breakdown_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :return: Dictionary of theme -> breakdowns.
+    :rtype: dict of str -> (str -> (int | str))
+    """
+    themes = OrderedDict()  # of theme -> breakdowns
+
+    # Create initial breakdowns dicts for 'Total Participants' and for each theme in this theme_configuration.
     themes["Total Relevant Participants"] = _make_breakdowns_dict(breakdown_configurations)
-    for code in _non_stop_codes(theme_config.code_scheme.codes):
-        themes[f"{theme_config.dataset_name}_{code.string_value}"] = _make_breakdowns_dict(breakdown_configurations)
+    for code in _non_stop_codes(theme_configuration.code_scheme.codes):
+        themes[f"{theme_configuration.dataset_name}_{code.string_value}"] = \
+            _make_breakdowns_dict(breakdown_configurations)
 
-    # Iterate over the individuals, increasing the counts as needed
+    # Iterate over the individuals, incrementing:
+    #  - The Total Relevant Participants, if the individual is considered relevant under this theme_configuration.
+    #  - The breakdowns dicts for each theme that this individual is labelled to have.
     for ind in individuals:
-        if analysis_utils.relevant(ind, consent_withdrawn_field, theme_config):
-            _update_breakdowns(themes["Total Relevant Participants"], ind, breakdown_configurations)
+        if analysis_utils.relevant(ind, consent_withdrawn_field, theme_configuration):
+            _increment_breakdowns(themes["Total Relevant Participants"], ind, breakdown_configurations)
 
-        for code in analysis_utils.get_codes_from_td(ind, theme_config):
-            _update_breakdowns(themes[f"{theme_config.dataset_name}_{code.string_value}"],
-                               ind, breakdown_configurations)
+        for code in analysis_utils.get_codes_from_td(ind, theme_configuration):
+            _increment_breakdowns(themes[f"{theme_configuration.dataset_name}_{code.string_value}"],
+                                  ind, breakdown_configurations)
 
+    # Compute the percentages in each breakdown dict, for the Total Relevant Participants and for each theme,
+    # relative to the Total Relevant Participants.
     _compute_breakdown_percentages(
         themes["Total Relevant Participants"], themes["Total Relevant Participants"],
         breakdown_configurations
     )
-
-    for code in _normal_codes(theme_config.code_scheme.codes):
+    for code in _normal_codes(theme_configuration.code_scheme.codes):
         _compute_breakdown_percentages(
-            themes[f"{theme_config.dataset_name}_{code.string_value}"], themes["Total Relevant Participants"],
+            themes[f"{theme_configuration.dataset_name}_{code.string_value}"], themes["Total Relevant Participants"],
             breakdown_configurations
         )
 
@@ -84,30 +183,81 @@ def _compute_theme_distributions_for_dataset(individuals, consent_withdrawn_fiel
 
 
 def compute_theme_distributions(individuals, consent_withdrawn_field, theme_configurations, breakdown_configurations):
-    theme_distributions = OrderedDict()  # of dataset_name -> theme ->
+    """
+    Computes the theme distributions for a list of individuals.
 
+    Returns a dictionary of theme dataset_name -> theme -> breakdowns.
+
+    :param individuals: Individuals to compute the theme_distributions for.
+    :type individuals: iterable of core_data_modules.traced_data.TracedData
+    :param consent_withdrawn_field: Field in each individuals object which records if consent is withdrawn.
+    :type consent_withdrawn_field: str
+    :param theme_configurations: Configuration for the themes. Each configuration should contain:
+                                  - dataset_name. This will be used to index the returned theme_distributions dict
+                                    (the "theme dataset_name" above).
+                                  - code_scheme. This will be used to index each themes dictionary in the returned
+                                    theme_distributions dict (the "theme" above). Themes are formatted as
+                                    {theme_configuration.dataset_name}_{code.string_value} for each code in the
+                                    code_scheme.
+    :type theme_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :param breakdown_configurations: Configuration for the breakdowns dict.
+                                     For details, see `theme_distributions._make_breakdowns_dict`.
+    :type breakdown_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :return: Dictionary of theme dataset_name -> theme -> breakdowns.
+    :rtype: dict of str -> str -> (str -> (int | str))
+    """
     individuals = analysis_utils.filter_opt_ins(individuals, consent_withdrawn_field, theme_configurations)
 
-    # For each theme configuration, create a dict of theme dataset_name -> (dict of breakdown code -> count/%)
+    theme_distributions = OrderedDict()  # of dataset_name -> theme -> breakdowns
     for theme_config in theme_configurations:
-        theme_distributions[theme_config.dataset_name] = _compute_theme_distributions_for_dataset(
+        theme_distributions[theme_config.dataset_name] = _compute_theme_distributions_for_theme_configuration(
             individuals, consent_withdrawn_field, theme_config, breakdown_configurations
         )
 
     return theme_distributions
 
 
-def write_theme_distributions_csv(individuals, consent_withdrawn_field, theme_configurations, breakdown_configurations, f):
+def write_theme_distributions_csv(individuals, consent_withdrawn_field,
+                                  theme_configurations, breakdown_configurations, f):
+    """
+    Computes the theme_distributions and writes them to a CSV.
+
+    The CSV will contain the headers:
+     - Dataset, set to the dataset_name in each of the `theme_configurations`, de-duplicated for clarity).
+     - Theme, set to {dataset_name}_{code.string_value}, for each code in each theme_configuration.
+     - Total Participants
+     - Total Participants %
+    and raw total and % headers for each scheme and code in the `breakdown_configurations`.
+
+    :param individuals: Individuals to compute the theme_distributions for.
+    :type individuals: iterable of core_data_modules.traced_data.TracedData
+    :param consent_withdrawn_field: Field in each individuals object which records if consent is withdrawn.
+    :type consent_withdrawn_field: str
+    :param theme_configurations: Configuration for the themes. Each configuration should contain:
+                                  - dataset_name. This will be used to index the returned theme_distributions dict
+                                    (the "theme dataset_name" above).
+                                  - code_scheme. This will be used to index each themes dictionary in the returned
+                                    theme_distributions dict (the "theme" above). Themes are formatted as
+                                    {theme_configuration.dataset_name}_{code.string_value} for each code in the
+                                    code_scheme.
+    :type theme_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :param breakdown_configurations: Configuration for the breakdowns dict.
+                                     For details, see `theme_distributions._make_breakdowns_dict`.
+    :type breakdown_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :param f: File to write the theme_distributions CSV to.
+    :type f: file-like
+    """
     theme_distributions = compute_theme_distributions(individuals, consent_withdrawn_field,
                                                       theme_configurations, breakdown_configurations)
 
+    # Denormalize the theme_distributions into a flat array of dicts that can be written to disk.
     csv_data = []
     last_dataset_name = None
     for dataset_name, themes in theme_distributions.items():
         for theme, breakdowns in themes.items():
             row = {
-                "Theme": theme,
-                "Dataset": dataset_name if dataset_name != last_dataset_name else ""
+                "Dataset": dataset_name if dataset_name != last_dataset_name else "",
+                "Theme": theme
             }
             row.update(breakdowns)
             csv_data.append(row)


### PR DESCRIPTION
This extracts engagement counts, theme distributions, and analysis utils functionality from the pipelines, and adapts it into Core. 

Engagement counts and analysis utils are similar to the implementations in the pipelines, but with improved internal documentation and references to CodingPlans and CodingConfigurations removed. I still found the need to pass through some of the fields we’re familiar with as a group though, so created an AnalysisConfiguration data-class instead for this. In the pipelines, we’ll need to map from the coding plan/coding configuration into this simpler configuration type. Suggestions for improved naming or an improved structure that doesn’t need such a data-class very welcomed :)

Theme distributions was substantially rewritten to be shorter and hopefully clearer. The fundamental approach is the same, but the code now more concise, better sign posted, and the terminology improved.

To use these new functions in automated_analysis we just need to replace all of the implementations with something like:
```python
def coding_plans_to_analysis_configurations(coding_plans):
    analysis_configurations = []
    for plan in coding_plans:
        for cc in plan.coding_configurations:
            analysis_configurations.append(
                AnalysisConfiguration(cc.analysis_file_key, cc.coded_field, cc.code_scheme)
            )
    return analysis_configurations

# Engagement Counts
log.info("Computing engagement counts...")
with open(f"{automated_analysis_output_dir}/engagement_counts.csv", "w") as f:
    engagement_counts.export_engagement_counts_csv(
        messages, individuals, CONSENT_WITHDRAWN_KEY,
        coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
        f
    )

# Theme distributions
log.info("Computing theme distributions...")
with open(f"{automated_analysis_output_dir}/theme_distributions.csv", "w") as f:
    theme_distributions.export_theme_distributions_csv(
        individuals, CONSENT_WITHDRAWN_KEY,
        coding_plans_to_analysis_configurations(PipelineConfiguration.RQA_CODING_PLANS),
        coding_plans_to_analysis_configurations(PipelineConfiguration.SURVEY_CODING_PLANS),
        f
    )
```
which is much easier to work with and maintain in the pipelines :)
I’ve run the above in the USAID-IBTCI pipeline and confirmed that the output numbers are the same.

If there any fundamental issues with the approach now would be the time to work through them, as this PR will set the direction for migrating the remaining CSVs we export in automated_analysis.