### PR TITLE
Add analysis.sample_messages

### DIFF
--- a/core_data_modules/analysis/analysis_utils.py
+++ b/core_data_modules/analysis/analysis_utils.py
@@ -5,8 +5,9 @@ from core_data_modules.data_models.code_scheme import CodeTypes
 
 
 class AnalysisConfiguration(object):
-    def __init__(self, dataset_name, coded_field, code_scheme):
+    def __init__(self, dataset_name, raw_field, coded_field, code_scheme):
         self.dataset_name = dataset_name
+        self.raw_field = raw_field
         self.coded_field = coded_field
         self.code_scheme = code_scheme
 

--- a/core_data_modules/analysis/sample_messages.py
+++ b/core_data_modules/analysis/sample_messages.py
@@ -1,0 +1,92 @@
+import random
+import sys
+from collections import OrderedDict
+
+from core_data_modules.analysis import analysis_utils
+
+sample_messages_keys = ["Episode", "Code Scheme", "Code", "Sample Message"]
+
+
+def _filter_codes_by_ids(codes, code_ids=None):
+    if code_ids is None:
+        return codes
+
+    return [code for code in codes if code.code_id in code_ids]
+
+
+def compute_sample_messages(messages, consent_withdrawn_field, analysis_configurations,
+                            filter_code_ids=None, limit_per_code=sys.maxsize):
+    """
+    Exports sample messages with each code in the code schemes in the given analysis_configurations.
+
+    :param messages: Objects to sample the messages from.
+    :type messages: iterable of core_data_modules.traced_data.TracedData
+    :param consent_withdrawn_field: Field in each messages object which records if consent is withdrawn.
+    :type consent_withdrawn_field: str
+    :param analysis_configurations: Configurations for the datasets to include in the sample_messages.
+    :type analysis_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :param filter_code_ids: The code ids to sample messages for, or None. If None, exports sample messages for all
+                            code ids.
+    :type filter_code_ids: list of str | None
+    :param limit_per_code: The maximum number of sample messages to export per code.
+                           Defaults to sys.maxsize, i.e. to no practical limit.
+    :type limit_per_code: int
+    :return: List of dictionaries with keys `sample_messages_keys`.
+    :rtype: list of dict
+    """
+    samples = []   # of dict with keys `sample_messages_keys`.
+
+    for config in analysis_configurations:
+        # Iterate over the labelled messages, filling out code_to_messages with the full list of messages labelled
+        # with each code
+        code_to_messages = OrderedDict()  # of code.string_value -> list of raw message strings
+        for code in _filter_codes_by_ids(config.code_scheme.codes, filter_code_ids):
+            code_to_messages[code.string_value] = []
+
+        for msg in analysis_utils.filter_partially_labelled(messages, consent_withdrawn_field, [config]):
+            msg_codes = analysis_utils.get_codes_from_td(msg, config)
+            for code in _filter_codes_by_ids(msg_codes, filter_code_ids):
+                code_to_messages[code.string_value].append(msg[config.raw_field])
+
+        # For each code, export up to the `limit_per_code` number of sample messages
+        for code_string_value in code_to_messages:
+            sample_size = min(limit_per_code, len(code_to_messages[code_string_value]))
+            sample_messages = random.sample(code_to_messages[code_string_value], sample_size)
+
+            for msg in sample_messages:
+                samples.append({
+                    "Episode": config.raw_field,
+                    "Code Scheme": config.code_scheme.name,
+                    "Code": code_string_value,
+                    "Sample Message": msg
+                })
+
+    return samples
+
+
+def export_sample_messages_csv(messages, consent_withdrawn_field, analysis_configurations, f,
+                               filter_code_ids=None, limit_per_code=sys.maxsize):
+    """
+    Computes the sample messages and exports them to a CSV.
+
+    :param messages: Objects to sample the messages from.
+    :type messages: iterable of core_data_modules.traced_data.TracedData
+    :param consent_withdrawn_field: Field in each messages object which records if consent is withdrawn.
+    :type consent_withdrawn_field: str
+    :param analysis_configurations: Configurations for the datasets to include in the sample_messages.
+    :type analysis_configurations: iterable of core_data_modules.analysis.AnalysisConfiguration
+    :param f: File to write the sample_messages CSV to.
+    :type f: file-like
+    :param filter_code_ids: The code ids to sample messages for, or None. If None, exports sample messages for all
+                            code ids.
+    :type filter_code_ids: list of str | None
+    :param limit_per_code: The maximum number of sample messages to export per code.
+                           Defaults to sys.maxsize, i.e. to no practical limit.
+    :type limit_per_code: int
+    """
+    analysis_utils.write_csv(
+        compute_sample_messages(messages, consent_withdrawn_field, analysis_configurations,
+                                filter_code_ids, limit_per_code),
+        sample_messages_keys,
+        f
+    )

--- a/core_data_modules/analysis/sample_messages.py
+++ b/core_data_modules/analysis/sample_messages.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from core_data_modules.analysis import analysis_utils
 
-sample_messages_keys = ["Episode", "Code Scheme", "Code", "Sample Message"]
+sample_messages_keys = ["Episode", "Code Scheme", "Code", "Message"]
 
 
 def _filter_codes_by_ids(codes, code_ids=None):
@@ -58,7 +58,7 @@ def compute_sample_messages(messages, consent_withdrawn_field, analysis_configur
                     "Episode": config.raw_field,
                     "Code Scheme": config.code_scheme.name,
                     "Code": code_string_value,
-                    "Sample Message": msg
+                    "Message": msg
                 })
 
     return samples


### PR DESCRIPTION
Adapted from the version in IBTCI.

This includes optional parameters for limiting the number of messages per code and for filtering the code_ids to include, which should allow this function to support the main two sampling use cases on projects at the moment: Sampling 100 messages from all codes, and exporting all messages that are e.g. impact, or accountability/safeguarding etc.