### PR TITLE
Fix tests failing due to the new release of matplotlib 3.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ setup(
     extras_require={
         # Version constraints, the explicit reference to scipy, and the backport dependency `importlib_resources` are
         # needed to support python 3.6. If python_requires is bumped to >=3.7.0, these constraints can be removed.
-        "mapping": ["numpy<1.20", "scipy<1.6.0", "pandas<1.2.0", "matplotlib", "geopandas", "descartes", "mapclassify",
-                    "importlib_resources"]
+        "mapping": ["numpy<1.20", "scipy<1.6.0", "pandas<1.2.0", "matplotlib<3.4.0", "geopandas", "descartes",
+                    "mapclassify", "importlib_resources"]
     },
     tests_require=["pytest<=3.6.4"]
 )


### PR DESCRIPTION
Matplotlib 3.4.0 dropped support for Python 3.6, 8 months earlier than 3.6's official end of life, so we have to add another version constraint to keep CoreDataModules supporting 3.6. Note that many scientific/numeric libraries have dropped support for 3.6 now, so we should aim to fully migrate away ourselves in the next few weeks.