### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,12 +25,6 @@ commands:
       - store_test_results:
           path: ~/test-results
 jobs:
-  py-3-6:
-    docker:
-      - image: cimg/base:2020.01
-    steps:
-      - test-python:
-          python-version: "3.6"
   py-3-7:
     docker:
       - image: cimg/base:2020.01
@@ -47,6 +41,5 @@ workflows:
   version: 2
   build-and-test:
     jobs:
-      - py-3-6
       - py-3-7
       - py-3-8

--- a/core_data_modules/analysis/mapping/mapping_utils.py
+++ b/core_data_modules/analysis/mapping/mapping_utils.py
@@ -8,12 +8,7 @@ try:
     from matplotlib.patches import Patch
     from mpl_toolkits.axes_grid1.inset_locator import zoomed_inset_axes
 
-    try:
-        # For Python 3.7+
-        import importlib.resources as resources
-    except ImportError:
-        # Use backport for Python 3.6
-        import importlib_resources as resources
+    import importlib.resources as resources
 except ImportError as e:
     raise ImportError("A mapping dependency couldn't be imported. To use the core_data_modules.analysis.mapping "
                       "module, make sure core_data_modules' `mapping` extra is installed") from e

--- a/core_data_modules/data_models/validators.py
+++ b/core_data_modules/data_models/validators.py
@@ -1,4 +1,3 @@
-import sys
 from datetime import datetime
 from urllib.parse import urlparse
 
@@ -42,30 +41,20 @@ def validate_datetime(dt, variable_name=""):
     return dt
 
 
-if sys.version_info >= (3, 7):
-    # Most iso validations happen on machine-generated strings which are in a very specific sub-set format of
-    # the ISO8601 standard. For speed, use the highly-optimized native checker available in Python 3.7+, and only fall
-    # back to the more generic isoparse if this fails.
-    # In our experiments, datetime.fromisoformat is about 20x faster than isoparse.
-    def validate_iso_string(s, variable_name=""):
-        validate_string(s, variable_name)
-        try:
-            datetime.fromisoformat(s.replace("Z", "+00:00"))
-        except ValueError:
-            try:
-                isoparse(s)
-            except ValueError:
-                assert False, "{} not an ISO string".format(variable_name)
-        return s
-else:
-    # Use isoparse only, as datetime.fromisoformat was only introduced in Python 3.7.
-    def validate_iso_string(s, variable_name=""):
-        validate_string(s, variable_name)
+# Most iso validations happen on machine-generated strings which are in a very specific sub-set format of
+# the ISO8601 standard. For speed, use the highly-optimized native checker available in Python 3.7+, and only fall
+# back to the more generic isoparse if this fails.
+# In our experiments, datetime.fromisoformat is about 20x faster than isoparse.
+def validate_iso_string(s, variable_name=""):
+    validate_string(s, variable_name)
+    try:
+        datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
         try:
             isoparse(s)
         except ValueError:
             assert False, "{} not an ISO string".format(variable_name)
-        return s
+    return s
 
 
 def validate_utc_iso_string(s, variable_name=""):

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,14 @@ from setuptools import setup
 setup(
     name="CoreDataModules",
     version="0.15.4",
-    python_requires=">=3.6.0",
+    python_requires=">=3.7.0",
     url="https://github.com/AfricasVoices/CoreDataModules",
     packages=["core_data_modules"],
     setup_requires=["pytest-runner"],
-    install_requires=["python-dateutil", "pytz", "firebase_admin", "pyparsing==2.4.7"],
+    install_requires=["protobuf<3.18.0", "google-auth<2", "pyparsing<3",  # Compatibility constraints for firebase_admin
+                      "firebase_admin", "python-dateutil", "pytz"],
     extras_require={
-        # Version constraints, the explicit references to scipy and pyproj, and the backport dependency
-        # `importlib_resources` are needed to support python 3.6.
-        # If python_requires is bumped to >=3.7.0, these constraints can be removed.
-        "mapping": ["pyproj<3.1.0", "numpy<1.20", "scipy<1.6.0", "pandas<1.2.0", "matplotlib<3.4.0", "geopandas",
-                    "descartes", "mapclassify", "importlib_resources"]
+        "mapping": ["numpy", "pandas", "matplotlib<3.4.0", "geopandas", "descartes", "mapclassify"]
     },
     tests_require=["pytest<=3.6.4"]
 )


### PR DESCRIPTION
We've hit another compatibility with our dependencies under 3.6. Last time we faced this problem we agreed that would be the last time we tried to fix it, as all our projects have now moved away from 3.6. 