### PR TITLE
Run dependency resolution using pip rather than setuptools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 ARG PYTHON_VERSION
 FROM python:${PYTHON_VERSION}-slim
 
+RUN pip install pytest
+
 WORKDIR /app
-
 ADD . /app
+RUN pip install -e .[mapping]
 
-CMD python setup.py test --extras --addopts "--doctest-modules --junitxml=test_results.xml"
+CMD pytest --doctest-modules --junitxml=test_results.xml


### PR DESCRIPTION
The tests on master are failing to initialise again due to a problem with the dependency resolution, even though CoreDataModules installs fine on projects. One of the problems here is that the dependency resolver used by setuptools is much less sophisticated than the one used by pipenv: roughly speaking, pipenv searches the available versions and dependency constraints until it a finds a valid solution, whereas setuptools installs the latest version of each package and hopes for the best.

So that we don't have to manually specify version constraints every few weeks, as we have been doing at the moment, this updates the test scripts to install dependencies using pip and then run pytest directly, rather than asking setuptools to do those things.

(the 3.8 tests are still failing, but this is for a different reason now (image tolerances). I will fix those tests separately).