### PR TITLE
Reduce image tolerances

### DIFF
--- a/tests/analysis/mapping/test_kenya_mapper.py
+++ b/tests/analysis/mapping/test_kenya_mapper.py
@@ -8,7 +8,7 @@ from matplotlib.testing.compare import compare_images
 
 from core_data_modules.analysis.mapping import kenya_mapper, mapping_utils
 
-_IMAGE_TOLERANCE = 0.0000001
+_IMAGE_TOLERANCE = 0.1
 
 
 class TestKenyaMapper(unittest.TestCase):

--- a/tests/analysis/mapping/test_somalia_mapper.py
+++ b/tests/analysis/mapping/test_somalia_mapper.py
@@ -8,7 +8,7 @@ from matplotlib.testing.compare import compare_images
 
 from core_data_modules.analysis.mapping import mapping_utils, somalia_mapper
 
-_IMAGE_TOLERANCE = 0.0000001
+_IMAGE_TOLERANCE = 0.1
 
 
 class TestKenyaMapper(unittest.TestCase):


### PR DESCRIPTION
Our initial image tolerances were extremely conservative and caused tests to be extremely sensitive to extremely small changes in outputs. I've tested a change with tolerance of 2 and found it imperceptible, so have relaxed the tolerances.