### PR TITLE
Test engagement counts

### DIFF
--- a/tests/analysis/AnalysisTestCase.py
+++ b/tests/analysis/AnalysisTestCase.py
@@ -10,12 +10,31 @@ class AnalysisTestCase(unittest.TestCase):
     analysis_data = generate_synthetic_analysis_data()
 
     def setUp(self):
+        """
+        Assigns a temporary working directory to `self.test_dir`, which subclasses can use to write temporary test data
+        to.
+
+        See also: `unittest.TestCase.setUp`, which this method implements.
+        """
         self.test_dir = tempfile.mkdtemp()
 
     def tearDown(self):
+        """
+        Deletes the temporary working directory.
+
+        See also: `unittest.TestCase.tearDown`, which this method implements.
+        """
         shutil.rmtree(self.test_dir)
 
-    def assertFilesEqual(self, a, b):
-        self.assertTrue(filecmp.cmp(a, b))
+    def assertFilesEqual(self, file_path_a, file_path_b):
+        """
+        Asserts the files at the two referenced paths have contents that match exactly.
+
+        :param file_path_a: Path to the first file to compare.
+        :type file_path_a: str
+        :param file_path_b: Path to the other file to compare.
+        :type file_path_b: str
+        """
+        self.assertTrue(filecmp.cmp(file_path_a, file_path_b))
 
 

--- a/tests/analysis/AnalysisTestCase.py
+++ b/tests/analysis/AnalysisTestCase.py
@@ -1,0 +1,21 @@
+import filecmp
+import shutil
+import tempfile
+import unittest
+
+from tests.analysis.generate_analysis_test_dataset import generate_synthetic_analysis_data
+
+
+class AnalysisTestCase(unittest.TestCase):
+    analysis_data = generate_synthetic_analysis_data()
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def assertFilesEqual(self, a, b):
+        self.assertTrue(filecmp.cmp(a, b))
+
+

--- a/tests/analysis/generate_analysis_test_dataset.py
+++ b/tests/analysis/generate_analysis_test_dataset.py
@@ -1,0 +1,158 @@
+import json
+import uuid
+from dataclasses import dataclass
+from random import Random
+from typing import List
+
+from core_data_modules.analysis import AnalysisConfiguration
+from core_data_modules.cleaners import Codes
+from core_data_modules.data_models import Label, Origin, CodeScheme, CodeTypes
+from core_data_modules.traced_data import TracedData, Metadata
+from core_data_modules.util import TimeUtils
+
+PARTICIPANT_UUID_FIELD = "participant_uuid"
+CONSENT_WITHDRAWN_FIELD = "consent_withdrawn"
+
+
+def _create_label(code, config):
+    origin = Origin(Metadata.get_call_location(depth=2), "test", "External")
+    label = Label(config.code_scheme.scheme_id, code.code_id, TimeUtils.utc_now_as_iso_string(), origin,
+                  checked=True)
+    return label
+
+
+def _generate_column_td(random, rqa_configs, demographic_configs, na_configs=[]):
+    """
+    Generates a TracedData in column-format, representing either a message or a participant, by assigning random codes
+    for the provided code schemes.
+
+    Automatically assigns a random participant id, consent status, and labels.
+
+    :param random: Random number generator to use. Providing a random number generator with the same seed will always
+                   generate the same output.
+    :type random: random.Random
+    :param rqa_configs: RQA configurations to input between 1 and 3 random codes for.
+    :type rqa_configs: list of AnalysisConfiguration
+    :param demographic_configs: Demographic configurations to input a random code for.
+    :type demographic_configs: list of AnalysisConfiguration
+    :param na_configs: Configurations to assign the code 'NA'. For example, this can be used to set some datasets to
+                       'NA' when creating a message.
+    :type na_configs: list of AnalysisConfiguration
+    """
+    # 10 % chance of withdrawing consent
+    consent_withdrawn = Codes.TRUE if random.random() > 0.9 else Codes.FALSE
+
+    data = {
+        PARTICIPANT_UUID_FIELD: f"participant-{uuid.uuid4()}",
+        CONSENT_WITHDRAWN_FIELD: consent_withdrawn
+    }
+
+    if consent_withdrawn:
+        for config in rqa_configs + demographic_configs:
+            stop_code = config.code_scheme.get_code_with_control_code(Codes.STOP)
+            label = _create_label(stop_code, config)
+            data[config.coded_field] = [label.to_dict()]
+            data[config.raw_field] = "STOP"
+
+    # Assign a control code, or between 1 and 3 other codes for each rqa_config.
+    for config in rqa_configs:
+        data[config.coded_field] = []
+        data[config.raw_field] = ""
+
+        control = True if random.random() > 0.8 else False
+        if control:
+            control_codes = [c for c in config.code_scheme.codes if c.code_type == CodeTypes.CONTROL and c.control_code != Codes.STOP]
+            code = random.choice(control_codes)
+            label = _create_label(code, config)
+            data[config.coded_field].append(label.to_dict())
+            data[config.raw_field] += f"Synthetic raw text: {code.string_value}; "
+        else:
+            non_control_codes = [c for c in config.code_scheme.codes if c.code_type != CodeTypes.CONTROL]
+            for i in range(random.choice([1, 2, 3])):
+                code = random.choice(non_control_codes)
+                label = _create_label(code, config)
+                data[config.coded_field].append(label.to_dict())
+                data[config.raw_field] += f"Synthetic raw text: {code.string_value}; "
+
+    # Assign the code 'NA' to all the NA configs.
+    for config in na_configs:
+        na_code = config.code_scheme.get_code_with_control_code(Codes.TRUE_MISSING)
+        data[config.coded_field] = _create_label(na_code, config).to_dict()
+        data[config.raw_field] = ""
+
+    # Select a single, random code for each demographic.
+    for config in demographic_configs:
+        non_stop_codes = [c for c in config.code_scheme.codes if c.control_code != Codes.STOP]
+        code = random.choice(non_stop_codes)
+        label = _create_label(code, config)
+        data[config.coded_field] = [label.to_dict()]
+        data[config.raw_field] = f"Synthetic raw text: {code.string_value}"
+
+    return TracedData(data, Metadata("test", Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string()))
+
+
+def _generate_demographic_configs():
+    with open("tests/analysis/resources/gender_code_scheme.json") as f:
+        gender_scheme = CodeScheme.from_firebase_map(json.load(f))
+
+    demographic_configs = [
+        AnalysisConfiguration(dataset_name="gender", raw_field="gender_raw", coded_field="gender_coded",
+                              code_scheme=gender_scheme)
+    ]
+
+    return demographic_configs
+
+
+def _generate_rqa_configs():
+    with open("tests/analysis/resources/s01e01_code_scheme.json") as f:
+        s01e01_scheme = CodeScheme.from_firebase_map(json.load(f))
+    with open("tests/analysis/resources/s01e02_code_scheme.json") as f:
+        s01e02_scheme = CodeScheme.from_firebase_map(json.load(f))
+
+    rqa_configs = [
+        AnalysisConfiguration(dataset_name="s01e01", raw_field="s01e01_raw", coded_field="s01e01_coded",
+                              code_scheme=s01e01_scheme),
+        AnalysisConfiguration(dataset_name="s01e02", raw_field="s01e02_raw", coded_field="s01e02_coded",
+                              code_scheme=s01e02_scheme)
+    ]
+
+    return rqa_configs
+
+
+@dataclass
+class SyntheticAnalysisData:
+    PARTICIPANT_UUID_FIELD = PARTICIPANT_UUID_FIELD
+    CONSENT_WITHDRAWN_FIELD = CONSENT_WITHDRAWN_FIELD
+
+    participants: List[TracedData]
+    messages: List[TracedData]
+    rqa_configs: List[AnalysisConfiguration]
+    demographic_configs: List[AnalysisConfiguration]
+
+
+def generate_synthetic_analysis_data():
+    """
+    Generates synthetic analysis data for testing this project's automated analysis routines.
+
+    Note that the messages and participants are each random and contain independent data.
+
+    :return: Synthetic analysis data for testing automated analysis.
+    :rtype: SyntheticAnalysisData
+    """
+    random = Random(0)
+    rqa_configs = _generate_rqa_configs()
+    demographic_configs = _generate_demographic_configs()
+
+    # Generate 500 random participants
+    participants = []
+    for i in range(500):
+        participants.append(_generate_column_td(random, rqa_configs, demographic_configs))
+
+    # Generate 500 random messages for each RQA config
+    messages = []
+    for i in range(500):
+        for rqa_config in rqa_configs:
+            na_configs = [c for c in rqa_configs if c != rqa_config]
+            messages.append(_generate_column_td(random, [rqa_config], demographic_configs, na_configs))
+
+    return SyntheticAnalysisData(participants, messages, rqa_configs, demographic_configs)

--- a/tests/analysis/resources/expected/expected_engagement_counts.csv
+++ b/tests/analysis/resources/expected/expected_engagement_counts.csv
@@ -1,0 +1,4 @@
+"Dataset","Total Messages","Total Messages with Opt-Ins","Total Labelled Messages","Total Relevant Messages","Total Participants","Total Participants with Opt-Ins","Total Relevant Participants"
+"s01e01","-","424","413","78","-","423","87"
+"s01e02","-","428","416","128","-","434","116"
+"Total","1000","852","829","206","500","454","185"

--- a/tests/analysis/resources/gender_code_scheme.json
+++ b/tests/analysis/resources/gender_code_scheme.json
@@ -1,0 +1,232 @@
+{
+  "SchemeID": "Scheme-12cb6f95",
+  "Name": "Gender",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-63dcde9a",
+      "CodeType": "Normal",
+      "DisplayText": "man",
+      "NumericValue": 1,
+      "StringValue": "man",
+      "Shortcut": "m",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "male",
+        "man"
+      ]
+    },
+    {
+      "CodeID": "code-86a4602c",
+      "CodeType": "Normal",
+      "DisplayText": "woman",
+      "NumericValue": 2,
+      "StringValue" : "woman",
+      "Shortcut": "f",
+      "VisibleInCoda": true,
+      "MatchValues" : [
+        "female",
+        "woman"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+     {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "StringValue": "impact",
+      "NumericValue": -100140,
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/tests/analysis/resources/s01e01_code_scheme.json
+++ b/tests/analysis/resources/s01e01_code_scheme.json
@@ -1,0 +1,224 @@
+{
+  "SchemeID": "Scheme-1774e762",
+  "Name": "S01E01",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-d4c8a20f",
+      "CodeType": "Normal",
+      "DisplayText": "theme 1A",
+      "NumericValue": 1,
+      "StringValue": "theme_1a",
+      "VisibleInCoda": true,
+      "MatchValues" : []
+    },
+    {
+      "CodeID": "code-94874a45",
+      "CodeType": "Normal",
+      "DisplayText": "theme 1B",
+      "NumericValue": 2,
+      "StringValue" : "theme_1b",
+      "VisibleInCoda": true,
+      "MatchValues" : []
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+     {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "StringValue": "impact",
+      "NumericValue": -100140,
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/tests/analysis/resources/s01e02_code_scheme.json
+++ b/tests/analysis/resources/s01e02_code_scheme.json
@@ -1,0 +1,233 @@
+{
+  "SchemeID": "Scheme-d3dd928c",
+  "Name": "S01E02",
+  "Version": "0.0.0.6",
+  "Codes": [
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-c049ece8",
+      "CodeType": "Normal",
+      "DisplayText": "theme 2A",
+      "NumericValue": 1,
+      "StringValue": "theme_2a",
+      "VisibleInCoda": true,
+      "MatchValues" : []
+    },
+    {
+      "CodeID": "code-795eafc3",
+      "CodeType": "Normal",
+      "DisplayText": "theme 2B",
+      "NumericValue": 2,
+      "StringValue" : "theme_2b",
+      "VisibleInCoda": true,
+      "MatchValues" : []
+    },
+    {
+      "CodeID": "code-17beface",
+      "CodeType": "Normal",
+      "DisplayText": "theme 2C",
+      "NumericValue": 3,
+      "StringValue" : "theme_2c",
+      "VisibleInCoda": true,
+      "MatchValues" : []
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+     {
+      "CodeID": "code-NOC-4eb70633",
+      "ControlCode": "NOC",
+      "StringValue": "NOC",
+      "DisplayText": "Noise (Other Channel)",
+      "VisibleInCoda": true,
+      "NumericValue": -60,
+      "CodeType": "Control"
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt-in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "DisplayText": "meta: gratitude",
+      "NumericValue": -100100,
+      "StringValue": "gratitude",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-AC-9ed22631",
+      "CodeType": "Meta",
+      "MetaCode": "about_conversation",
+      "DisplayText": "meta: about conversation",
+      "NumericValue": -100120,
+      "StringValue": "about_conversation",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "NumericValue": -100130,
+      "StringValue": "chasing_reply",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "DisplayText": "meta: impact",
+      "StringValue": "impact",
+      "NumericValue": -100140,
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/tests/analysis/test_engagement_counts.py
+++ b/tests/analysis/test_engagement_counts.py
@@ -1,0 +1,16 @@
+from core_data_modules.analysis.engagement_counts import export_engagement_counts_csv
+from tests.analysis.AnalysisTestCase import AnalysisTestCase
+
+
+class TestEngagementCounts(AnalysisTestCase):
+    def test_export_engagement_counts(self):
+        analysis_data = self.analysis_data
+        file_path = f"{self.test_dir}/engagement_counts.csv"
+
+        with open(file_path, "w") as f:
+            export_engagement_counts_csv(
+                analysis_data.messages, analysis_data.participants, analysis_data.CONSENT_WITHDRAWN_FIELD,
+                analysis_data.rqa_configs, f
+            )
+
+        self.assertFilesEqual(file_path, "tests/analysis/resources/expected/expected_engagement_counts.csv")


### PR DESCRIPTION
This is the first step in adding tests for the automated analysis package.

It generates a synthetic, random dataset in the correct format, then tests the engagement_counts analysis so we can easily see the expected format for the results, and make sure the results don't accidentally change in future. If this looks good I will add some additional variables and extend to the rest of analysis, especially to the automated regression once that's ready.

Review #247 first.