### PR TITLE
Update PhoneCleaner.clean_operator() to map "25277" -> Hormuud

### DIFF
--- a/core_data_modules/cleaners/phone_cleaner.py
+++ b/core_data_modules/cleaners/phone_cleaner.py
@@ -73,6 +73,7 @@ class PhoneCleaner(object):
             "25267": SomaliaCodes.NATIONLINK,
             "25268": SomaliaCodes.SOMNET,
             "25269": SomaliaCodes.NATIONLINK,
+            "25277": SomaliaCodes.HORMUD,
             "25290": SomaliaCodes.GOLIS,
         }
 


### PR DESCRIPTION
The +25277 block was introduced in early 2023.